### PR TITLE
Update to RestSharp 121.1.0

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,13 +11,13 @@ jobs:
     runs-on: windows-latest
     steps:
     - name: Git Checkout
-      uses: actions/checkout@master
+      uses: actions/checkout@main
 
     - name: Setup Nuget.exe
-      uses: nuget/setup-nuget@v1
+      uses: nuget/setup-nuget@v2.0.0
       
     - name: Publish VL Nuget
-      uses: vvvv/PublishVLNuget@1.0.41
+      uses: vvvv/PublishVLNuget@1.0.43
       with:
         nuspec: deployment\VL.SimpleHTTP.nuspec
         nuget-key: ${{ secrets.NUGET_KEY }}

--- a/VL.SimpleHTTP.vl
+++ b/VL.SimpleHTTP.vl
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Document xmlns:p="property" Id="IhAai8K1SAGPWRXSVXLSZo" LanguageVersion="2021.4.11.1332" Version="0.128">
+<Document xmlns:p="property" xmlns:r="reflection" Id="IhAai8K1SAGPWRXSVXLSZo" LanguageVersion="2025.7.1-0042-gb4eb70cb8e" Version="0.128">
   <Patch Id="GV3GtGCIOPKL9lcXE5GFPq">
     <Canvas Id="QIyi0lygyYtLhVxEhy57Rr" DefaultCategory="IO.HTTP" CanvasType="FullCategory">
       <!--
@@ -7,19 +7,21 @@
     ************************ Request (Async) ************************
 
 -->
-      <Node Name="Request (Async)" Bounds="314,271" Id="D86Ay5zRJZNMtd83dHc56b" Summary="Makes an asynchronous HTTP request, without blocking the mainloop." Tags="http,get,post,put,query,request">
-        <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="builtin">
+      <Node Name="Request (Async)" Bounds="128,101" Id="D86Ay5zRJZNMtd83dHc56b" Summary="Makes an asynchronous HTTP request, without blocking the mainloop." Tags="http,get,post,put,query,request">
+        <p:NodeReference LastCategoryFullName="Primitive" LastDependency="builtin">
           <Choice Kind="ContainerDefinition" Name="Process" />
         </p:NodeReference>
         <Patch Id="V7y8P1p7UyEMZPPw2SIEUp">
           <Canvas Id="UZUMwNFo8ULMj2YTgICD5Z" CanvasType="Group">
-            <Node Bounds="344,300,189,73" Id="UgLMJCO5Yw2PaLSIQj6Kk5">
-              <p:NodeReference LastCategoryFullName="Reactive" LastSymbolSource="VL.Reactive.vl">
+            <Node Bounds="131,201,189,73" Id="UgLMJCO5Yw2PaLSIQj6Kk5">
+              <p:NodeReference LastCategoryFullName="Reactive" LastDependency="VL.Reactive.vl">
                 <Choice Kind="ProcessAppFlag" Name="AsyncTask" />
                 <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
               </p:NodeReference>
+              <Pin Id="B8YYo8PALPGOSU2suse55R" Name="Node Context" Kind="InputPin" IsHidden="true" />
               <Pin Id="E7IPH0a4dyXPsPNuOTpBW1" Name="Trigger" Kind="InputPin" />
               <Pin Id="ITBeHsxJhf2NKYTchzqiU3" Name="Abort" Kind="InputPin" />
+              <Pin Id="PZZDLeg1fMKL51BmdSikhe" Name="Output" Kind="OutputPin" IsHidden="true" />
               <Pin Id="HN59teb0szzLNhLLjiNZoW" Name="Result" Kind="OutputPin" />
               <Pin Id="FHKdBz9fIH6QccqK8KLIcd" Name="In Progress" Kind="OutputPin" />
               <Patch Id="Jzsu0fRw3gDOlefLJ5ThBt" ManuallySortedPins="true">
@@ -28,10 +30,10 @@
                   <Pin Id="HOvIp5xxsYjLDXhVNaoCY4" Name="Input 1" Kind="InputPin" />
                   <Pin Id="ONMF56HwQXFOpd0wkOfRB9" Name="Output" Kind="OutputPin" />
                 </Patch>
-                <ControlPoint Id="JQ3B0FzGFJfPNBfx9ZBNZ6" Bounds="477,319" />
-                <ControlPoint Id="DVaGn63Kvo6LuZlfdarK5A" Bounds="358,366" />
-                <Node Bounds="356,323,65,19" Id="JuT3OCDuGsIMJnyajQaKgI">
-                  <p:NodeReference>
+                <ControlPoint Id="JQ3B0FzGFJfPNBfx9ZBNZ6" Bounds="264,220" />
+                <ControlPoint Id="DVaGn63Kvo6LuZlfdarK5A" Bounds="145,267" />
+                <Node Bounds="143,224,94,19" Id="JuT3OCDuGsIMJnyajQaKgI">
+                  <p:NodeReference LastCategoryFullName="IO.HTTP" LastDependency="VL.SimpleHTTP.vl">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <Choice Kind="OperationCallFlag" Name="SimpleQueryBase" />
                   </p:NodeReference>
@@ -40,31 +42,35 @@
                   <Pin Id="DN2YlVJz25MOXvI4v6fOmG" Name="Body" Kind="InputPin" />
                   <Pin Id="JCtP3Iqy4dKOOBkKo5lOC9" Name="Method" Kind="InputPin" />
                   <Pin Id="I1nBYKh6shXLyOsN2hTBwF" Name="Result" Kind="OutputPin" />
+                  <Pin Id="D19kHHoFmGDOB2CWedehxC" Name="Timeout" Kind="InputPin" />
                 </Node>
               </Patch>
             </Node>
-            <ControlPoint Id="BVPLgf35iB6LTM6buSgu3q" Bounds="416,235" />
-            <ControlPoint Id="Jt0UFjfuYGNOAD1EC0IA41" Bounds="339,243" />
-            <ControlPoint Id="Pkiz9q9CGYkMw1fro6hc65" Bounds="490,242" />
-            <ControlPoint Id="SxUPsXAgfdiQCT3r64IAv0" Bounds="263,233" />
-            <ControlPoint Id="Tfz8YJ11qAXOcA8K0NgIM1" Bounds="275,523" />
-            <ControlPoint Id="GiizGmtgTDrPBpCzuJKKLB" Bounds="413,526" />
-            <ControlPoint Id="DnuyGZwAFYBP3qW7rhCWR1" Bounds="494,526" />
-            <ControlPoint Id="EpYkdfldwsfPt6WROHazid" Bounds="613,526" />
-            <Node Bounds="345,399,65,19" Id="OtD4Iv3Wo49M1e3mdWBKbr">
-              <p:NodeReference LastCategoryFullName="Reactive" LastSymbolSource="VL.Reactive.vl">
+            <ControlPoint Id="BVPLgf35iB6LTM6buSgu3q" Bounds="189,111" />
+            <ControlPoint Id="Jt0UFjfuYGNOAD1EC0IA41" Bounds="167,92" />
+            <ControlPoint Id="Pkiz9q9CGYkMw1fro6hc65" Bounds="212,141" />
+            <ControlPoint Id="SxUPsXAgfdiQCT3r64IAv0" Bounds="145,72" />
+            <ControlPoint Id="Tfz8YJ11qAXOcA8K0NgIM1" Bounds="134,481" />
+            <ControlPoint Id="GiizGmtgTDrPBpCzuJKKLB" Bounds="202,422" />
+            <ControlPoint Id="DnuyGZwAFYBP3qW7rhCWR1" Bounds="235,402" />
+            <ControlPoint Id="EpYkdfldwsfPt6WROHazid" Bounds="269,382" />
+            <Node Bounds="132,300,65,19" Id="OtD4Iv3Wo49M1e3mdWBKbr">
+              <p:NodeReference LastCategoryFullName="Reactive" LastDependency="VL.Reactive.vl">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <Choice Kind="ProcessAppFlag" Name="HoldLatest" />
               </p:NodeReference>
+              <Pin Id="CFnvHZphaqILTvnsIDT8nE" Name="Node Context" Kind="InputPin" IsHidden="true" />
+              <Pin Id="NafsP1eWSn7ORUVS31Uj2S" Name="Initial Result" Kind="InputPin" IsHidden="true" />
               <Pin Id="JxsoBaSIQqDOIjhcAdxeES" Name="Async Notifications" Kind="InputPin" />
               <Pin Id="VBNj9WI9mt5LlWmNynXLzS" Name="Reset" Kind="InputPin" />
+              <Pin Id="TS64B0JdsyYNJiiZv5R05r" Name="Output" Kind="OutputPin" IsHidden="true" />
               <Pin Id="AKVtL3hN3WPNsEZkLTEiuy" Name="Value" Kind="OutputPin" />
               <Pin Id="JtTveaNFhSGNXYY6GypAXo" Name="On Data" Kind="OutputPin" />
             </Node>
-            <ControlPoint Id="RQyk2uDfe07Os69Cl4MUgj" Bounds="703,526" />
-            <ControlPoint Id="CO16pwUA6s2NDeDVCsMS5e" Bounds="794,526" />
-            <Node Bounds="345,453,140,19" Id="MBoR2AJlOn2ML01ecuDSJq">
-              <p:NodeReference LastCategoryFullName="IO.HTTP" LastSymbolSource="VL.SimpleHTTP.vl">
+            <ControlPoint Id="RQyk2uDfe07Os69Cl4MUgj" Bounds="194,342" />
+            <ControlPoint Id="CO16pwUA6s2NDeDVCsMS5e" Bounds="317,322" />
+            <Node Bounds="132,354,140,19" Id="MBoR2AJlOn2ML01ecuDSJq">
+              <p:NodeReference LastCategoryFullName="IO.HTTP" LastDependency="VL.SimpleHTTP.vl">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <Choice Kind="OperationCallFlag" Name="RetrieveBasicResponseData" />
               </p:NodeReference>
@@ -75,8 +81,9 @@
               <Pin Id="LWwwXeh8VsUOfunCpMn4I3" Name="Status Description" Kind="OutputPin" />
               <Pin Id="MeL8J0RPc3vPeljNyH3JcH" Name="Is Successful" Kind="OutputPin" />
             </Node>
-            <ControlPoint Id="P3wJ7vrr6jmQcZ4BrRLY0p" Bounds="584,250" />
-            <ControlPoint Id="VPaSIUCTyzdLhbePaj7Z4L" Bounds="339,526" />
+            <ControlPoint Id="P3wJ7vrr6jmQcZ4BrRLY0p" Bounds="133,52" />
+            <ControlPoint Id="VPaSIUCTyzdLhbePaj7Z4L" Bounds="168,451" />
+            <ControlPoint Id="Sa3ApcVI1GvLQp2fAmgtAD" Bounds="234,170" />
           </Canvas>
           <ProcessDefinition Id="GkkYYs9mJMdMJ4aODjqNIf">
             <Fragment Id="EBJT7Vs2oQXPZ7IfX9QfcE" Patch="PWqO3CJaAxqO4KeDnuiwhU" Enabled="true" />
@@ -112,11 +119,12 @@
           <Link Id="UUz13xCJ8zMPLdwvNJ9Fj7" Ids="ADepidYJHz4PXbIKoyPCyx,VPaSIUCTyzdLhbePaj7Z4L" />
           <Link Id="HsV36qq6QSWPK1Q9olTMLH" Ids="VPaSIUCTyzdLhbePaj7Z4L,EgeT28KIyGvO7rk2Xyo00j" IsHidden="true" />
           <Patch Id="PWqO3CJaAxqO4KeDnuiwhU" Name="Create" />
-          <Patch Id="H90Grteqp5ePUBVfAL5FBp" Name="Update">
+          <Patch Id="H90Grteqp5ePUBVfAL5FBp" Name="Update" ManuallySortedPins="true">
             <Pin Id="HfEHPnuPwkGLIhhBVjtIgh" Name="URL" Kind="InputPin" Bounds="313,222" />
             <Pin Id="VApwct0ccdRPogViOpOiW4" Name="Headers" Kind="InputPin" Bounds="428,252" />
             <Pin Id="B6Hj7xU5V7WMLnuUvc8VAc" Name="Body" Kind="InputPin" Bounds="484,272" />
             <Pin Id="H150h8tbIivPp2BQ3MkZ8R" Name="Method" Kind="InputPin" Bounds="378,232" />
+            <Pin Id="P9Nqt87da7UP2igUwJ7w6c" Name="Timeout" Kind="InputPin" />
             <Pin Id="K4HZQqrH8GuNalTMDGePZQ" Name="Refresh" Kind="InputPin" Bounds="584,250" />
             <Pin Id="AV4keCH50KkN1MXiZhGdKb" Name="Content" Kind="OutputPin" Bounds="459,565" />
             <Pin Id="EgeT28KIyGvO7rk2Xyo00j" Name="Raw Bytes" Kind="OutputPin" Bounds="347,532" Visibility="Optional" />
@@ -126,6 +134,8 @@
             <Pin Id="QR6qJhh7WGlLgxZ7e9eCvv" Name="On Data" Kind="OutputPin" Bounds="1207,530" />
             <Pin Id="Qa8xyt67B2LQHYCxqC2LN1" Name="In Progress" Kind="OutputPin" Bounds="831,630" />
           </Patch>
+          <Link Id="UGfD3HHcNdgQWQxlJXP1iU" Ids="Sa3ApcVI1GvLQp2fAmgtAD,D19kHHoFmGDOB2CWedehxC" />
+          <Link Id="EpFl6Dqw0DFMvNVirxJP3D" Ids="P9Nqt87da7UP2igUwJ7w6c,Sa3ApcVI1GvLQp2fAmgtAD" IsHidden="true" />
         </Patch>
       </Node>
       <!--
@@ -133,28 +143,30 @@
     ************************ Request (Blocking) ************************
 
 -->
-      <Node Name="Request (Blocking)" Bounds="314,317" Id="GTPXYWb4mtXNJvsF8PHEkj" Summary="Makes a blocking HTTP request, blocking the mainloop." Tags="http,get,post,put,query,request">
-        <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="builtin">
+      <Node Name="Request (Blocking)" Bounds="128,147" Id="GTPXYWb4mtXNJvsF8PHEkj" Summary="Makes a blocking HTTP request, blocking the mainloop." Tags="http,get,post,put,query,request">
+        <p:NodeReference LastCategoryFullName="Primitive" LastDependency="builtin">
           <Choice Kind="ContainerDefinition" Name="Process" />
         </p:NodeReference>
         <Patch Id="Hufyz6TRrOIPFLhgE25ttX">
           <Canvas Id="QTgXdHDBhTdOP63JlAO1fs" CanvasType="Group">
-            <ControlPoint Id="AskYbbqv0MIPnOoe3KmXQv" Bounds="156,196" />
-            <ControlPoint Id="CTbPmNnCw9CPKXX0sPq1iI" Bounds="331,196" />
-            <ControlPoint Id="OAFIhpqKAwzMhg5K8WKDFX" Bounds="213,197" />
-            <ControlPoint Id="JY0zJCsS98VOysbjVH2Rjn" Bounds="285,197" />
-            <ControlPoint Id="KzzsPhmorgfLhSQCrmKNTS" Bounds="63,501" />
-            <ControlPoint Id="I6uwAU5bNszO5szWAEwvvB" Bounds="206,501" />
-            <ControlPoint Id="JNagkcBa7fXM5briXJzZ3u" Bounds="292,501" />
-            <ControlPoint Id="BqObRymDNR0P4LHlxpWJ2j" Bounds="404,501" />
-            <Node Bounds="136,254,183,90" Id="MZbC7J1SuApNVB00FvCIu5">
-              <p:NodeReference LastCategoryFullName="Reactive" LastSymbolSource="VL.Reactive.vl">
+            <ControlPoint Id="AskYbbqv0MIPnOoe3KmXQv" Bounds="107,138" />
+            <ControlPoint Id="CTbPmNnCw9CPKXX0sPq1iI" Bounds="181,201" />
+            <ControlPoint Id="OAFIhpqKAwzMhg5K8WKDFX" Bounds="131,160" />
+            <ControlPoint Id="JY0zJCsS98VOysbjVH2Rjn" Bounds="156,171" />
+            <ControlPoint Id="KzzsPhmorgfLhSQCrmKNTS" Bounds="89,570" />
+            <ControlPoint Id="I6uwAU5bNszO5szWAEwvvB" Bounds="157,521" />
+            <ControlPoint Id="JNagkcBa7fXM5briXJzZ3u" Bounds="190,501" />
+            <ControlPoint Id="BqObRymDNR0P4LHlxpWJ2j" Bounds="224,481" />
+            <Node Bounds="87,254,183,90" Id="MZbC7J1SuApNVB00FvCIu5">
+              <p:NodeReference LastCategoryFullName="Reactive" LastDependency="VL.Reactive.vl">
                 <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
                 <Choice Kind="ProcessAppFlag" Name="ForEach" />
                 <CategoryReference Kind="Category" Name="Reactive" NeedsToBeDirectParent="true" />
               </p:NodeReference>
+              <Pin Id="QrI7lSAooeiO8f5u01PaHc" Name="Node Context" Kind="InputPin" IsHidden="true" />
               <Pin Id="PDuFwZAPvjiMP7i1GvGN6s" Name="Messages" Kind="InputPin" />
               <Pin Id="A1CSC6ftlIDK905msmXoMo" Name="Reset" Kind="InputPin" />
+              <Pin Id="UWKjJ4jAJuMQX93HzYVBty" Name="Output" Kind="OutputPin" IsHidden="true" />
               <Pin Id="C0JmjNUjLkXP7QWqdsq1Va" Name="Result" Kind="OutputPin" />
               <Patch Id="RbdY9L21E4INAfYUxBxbfI" ManuallySortedPins="true">
                 <Patch Id="PQR6XJH7yaBLzbItlJSpgI" Name="Create" ManuallySortedPins="true" />
@@ -162,10 +174,10 @@
                   <Pin Id="I49o1ZjW8oFOJQHxEvIFn7" Name="Input 1" Kind="InputPin" />
                   <Pin Id="TWn7ukrQoMTNOZpDw4luca" Name="Output" Kind="OutputPin" />
                 </Patch>
-                <ControlPoint Id="Dv9wTgML3JTM66PKwJTWjU" Bounds="140,262" />
-                <ControlPoint Id="GS6x6vrhMR4OoiEQRbIyGp" Bounds="155,337" />
-                <Node Bounds="153,291,-101,19" Id="De3OWAWunZxLca0GX6foAk">
-                  <p:NodeReference>
+                <ControlPoint Id="Dv9wTgML3JTM66PKwJTWjU" Bounds="91,262" />
+                <ControlPoint Id="GS6x6vrhMR4OoiEQRbIyGp" Bounds="106,337" />
+                <Node Bounds="104,291,105,19" Id="De3OWAWunZxLca0GX6foAk">
+                  <p:NodeReference LastCategoryFullName="IO.HTTP" LastDependency="VL.SimpleHTTP.vl">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <Choice Kind="OperationCallFlag" Name="SimpleQueryBase" />
                   </p:NodeReference>
@@ -174,21 +186,24 @@
                   <Pin Id="BgGof22YYJeLbn91E7074h" Name="Body" Kind="InputPin" />
                   <Pin Id="LLhwawYIWqHQB98NeNChlQ" Name="Method" Kind="InputPin" />
                   <Pin Id="BCv18SyzlL8O9RBeZhHAIc" Name="Result" Kind="OutputPin" />
+                  <Pin Id="HrvVR520EgUPy7sauew3Jx" Name="Timeout" Kind="InputPin" />
                 </Node>
               </Patch>
             </Node>
-            <Node Bounds="136,92,79,19" Id="LsneqlKBhiNOzRXROR2avM">
-              <p:NodeReference LastCategoryFullName="Reactive" LastSymbolSource="VL.Reactive.vl">
+            <Node Bounds="87,92,79,19" Id="LsneqlKBhiNOzRXROR2avM">
+              <p:NodeReference LastCategoryFullName="Reactive" LastDependency="VL.Reactive.vl">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <Choice Kind="ProcessAppFlag" Name="ToObservable" />
               </p:NodeReference>
+              <Pin Id="Aqpt34qwfafMRDL8i1IZN9" Name="Node Context" Kind="InputPin" IsHidden="true" />
               <Pin Id="UyOWknux5YjOoZcwE22Es6" Name="Message" Kind="InputPin" />
               <Pin Id="KqwgkJWuE3VLxlVaeyR2cr" Name="Send" Kind="InputPin" />
+              <Pin Id="PrK4k2WzJhjMGbhxuv2qP2" Name="Output" Kind="OutputPin" IsHidden="true" />
               <Pin Id="NJwQH0YnwUlQSot4llMGd7" Name="Result" Kind="OutputPin" />
             </Node>
-            <ControlPoint Id="QuGcGMJkOPEQWUE0YxlpqI" Bounds="212,72" />
-            <Pad Id="KaKv6A90ZoFQdow4rj1C2f" Comment="" Bounds="138,75,35,15" ShowValueBox="true" isIOBox="true" Value="False">
-              <p:TypeAnnotation>
+            <ControlPoint Id="QuGcGMJkOPEQWUE0YxlpqI" Bounds="163,72" />
+            <Pad Id="KaKv6A90ZoFQdow4rj1C2f" Comment="" Bounds="89,75,35,15" ShowValueBox="true" isIOBox="true" Value="False">
+              <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                 <Choice Kind="ImmutableTypeFlag" Name="Boolean" />
                 <FullNameCategoryReference ID="Primitive" />
               </p:TypeAnnotation>
@@ -196,19 +211,22 @@
                 <p:buttonmode p:Assembly="VL.UI.Forms" p:Type="VL.HDE.PatchEditor.Editors.ButtonModeEnum">Bang</p:buttonmode>
               </p:ValueBoxSettings>
             </Pad>
-            <Node Bounds="136,377,-337,19" Id="DJ5vZrgpYwzNYs6Jm1nR58">
-              <p:NodeReference LastCategoryFullName="Reactive" LastSymbolSource="VL.Reactive.vl">
+            <Node Bounds="87,377,65,19" Id="DJ5vZrgpYwzNYs6Jm1nR58">
+              <p:NodeReference LastCategoryFullName="Reactive" LastDependency="VL.Reactive.vl">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <Choice Kind="ProcessAppFlag" Name="HoldLatest" />
               </p:NodeReference>
+              <Pin Id="DsDKlmrl4SCP1RZI0ZDwLw" Name="Node Context" Kind="InputPin" IsHidden="true" />
+              <Pin Id="LdbkqWSyIHrMGIwJ8sg9Sp" Name="Initial Result" Kind="InputPin" IsHidden="true" />
               <Pin Id="RlJQHezeToKQc8YG367Zb1" Name="Async Notifications" Kind="InputPin" />
               <Pin Id="TWSxID0kpWNNkY24qfkUXV" Name="Reset" Kind="InputPin" />
+              <Pin Id="FkkvxiTXwjXPJtzSnqdON4" Name="Output" Kind="OutputPin" IsHidden="true" />
               <Pin Id="KPN3mcyk5cdPHvL82E57r8" Name="Value" Kind="OutputPin" />
               <Pin Id="IGiMdS6Pc0YPOCaSJkFkLn" Name="On Data" Kind="OutputPin" />
             </Node>
-            <ControlPoint Id="MQfSRDyeUQMPnI7xceVA69" Bounds="500,501" />
-            <Node Bounds="136,432,140,19" Id="A6EaVeGgRVRMSOn4Etcoez">
-              <p:NodeReference LastCategoryFullName="IO.HTTP" LastSymbolSource="VL.SimpleHTTP.vl">
+            <ControlPoint Id="MQfSRDyeUQMPnI7xceVA69" Bounds="149,411" />
+            <Node Bounds="87,432,140,19" Id="A6EaVeGgRVRMSOn4Etcoez">
+              <p:NodeReference LastCategoryFullName="IO.HTTP" LastDependency="VL.SimpleHTTP.vl">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <Choice Kind="OperationCallFlag" Name="RetrieveBasicResponseData" />
               </p:NodeReference>
@@ -219,7 +237,8 @@
               <Pin Id="O9Uie2LQPM0Pd8yM3Qrktv" Name="Status Description" Kind="OutputPin" />
               <Pin Id="B8vOroCrz9vLtqOE8h2b4c" Name="Is Successful" Kind="OutputPin" />
             </Node>
-            <ControlPoint Id="HtTkfKpQYV8NR8w6ndhMcD" Bounds="136,502" />
+            <ControlPoint Id="HtTkfKpQYV8NR8w6ndhMcD" Bounds="123,540" />
+            <ControlPoint Id="DXELNlR7nR8Lc4OnPVNC1w" Bounds="206,221" />
           </Canvas>
           <ProcessDefinition Id="Qdy7fYprCoQOpHzcwR7Dib">
             <Fragment Id="U7Il5XMEHXZLM7ix8gwxpb" Patch="OX7AJkBiqgjMaUB55Vsf8I" Enabled="true" />
@@ -249,16 +268,16 @@
           <Patch Id="OALq5HwlnGGMvWoGfubmsF" Name="Update" ManuallySortedPins="true">
             <Pin Id="UAllXsnKQZYNHqkC0DBV4k" Name="URL" Kind="InputPin" Bounds="498,323" />
             <Pin Id="OkDKhbMVdUDPGuKYMspnQd" Name="Headers" Kind="InputPin" Bounds="551,333">
-              <p:TypeAnnotation LastCategoryFullName="Collections" LastSymbolSource="VL.Collections.vl">
+              <p:TypeAnnotation LastCategoryFullName="Collections" LastDependency="VL.Collections.vl">
                 <Choice Kind="TypeFlag" Name="Spread" />
                 <p:TypeArguments>
-                  <TypeReference LastCategoryFullName="Collections.Common" LastSymbolSource="VL.Collections.vl">
+                  <TypeReference LastCategoryFullName="Collections.Common" LastDependency="VL.Collections.vl">
                     <Choice Kind="TypeFlag" Name="KeyValuePair" />
                     <p:TypeArguments>
-                      <TypeReference LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+                      <TypeReference LastCategoryFullName="Primitive" LastDependency="CoreLibBasics.vl">
                         <Choice Kind="TypeFlag" Name="String" />
                       </TypeReference>
-                      <TypeReference LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+                      <TypeReference LastCategoryFullName="Primitive" LastDependency="CoreLibBasics.vl">
                         <Choice Kind="TypeFlag" Name="String" />
                       </TypeReference>
                     </p:TypeArguments>
@@ -267,11 +286,12 @@
               </p:TypeAnnotation>
             </Pin>
             <Pin Id="ERHiUeeYVCQN3HeNvVSZcv" Name="Body" Kind="InputPin" Bounds="623,334">
-              <p:TypeAnnotation>
+              <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                 <Choice Kind="TypeFlag" Name="String" />
               </p:TypeAnnotation>
             </Pin>
             <Pin Id="MRS3DsEZQTuOTOnYuZlBo9" Name="Method" Kind="InputPin" Bounds="482,339" />
+            <Pin Id="OIoCnMSGiSwPoUHVLmhl2x" Name="Timeout" Kind="InputPin" />
             <Pin Id="SGShyWfJ2SsOHFLiVeD8Om" Name="Refresh" Kind="InputPin" Bounds="1104,297" />
             <Pin Id="AIVDbhRsIu5NRqhuvJk1sQ" Name="Content" Kind="OutputPin" Bounds="459,565" />
             <Pin Id="PsowzfJj4lgLaB0Ws2F5M4" Name="Status Code" Kind="OutputPin" Bounds="568,561" />
@@ -289,47 +309,64 @@
           <Link Id="FWFfADMdYQKOXH7CVH0ESQ" Ids="B8vOroCrz9vLtqOE8h2b4c,BqObRymDNR0P4LHlxpWJ2j" />
           <Link Id="PxHQg0Vr3xaPdWSQR4nbYO" Ids="Vm5hBH9plBJPQ8WLEO7SQG,HtTkfKpQYV8NR8w6ndhMcD" />
           <Link Id="Kkwhw5RpC19OudaiLGmFhw" Ids="HtTkfKpQYV8NR8w6ndhMcD,F6A8M87jR5WMosecOjnfUx" IsHidden="true" />
+          <Link Id="TMZ8w4UbgaULJNenDInm2m" Ids="DXELNlR7nR8Lc4OnPVNC1w,HrvVR520EgUPy7sauew3Jx" />
+          <Link Id="MgNqPAhNXfIPjF8ehJpjf4" Ids="OIoCnMSGiSwPoUHVLmhl2x,DXELNlR7nR8Lc4OnPVNC1w" IsHidden="true" />
         </Patch>
       </Node>
-      <Canvas Id="Ox2hlKFfrkNMjVUtMyhMzm" Name="Internal" Position="314,553">
+      <Canvas Id="Ox2hlKFfrkNMjVUtMyhMzm" Name="Internal" Position="128,383">
         <!--
 
     ************************ SimpleQueryBase ************************
 
 -->
-        <Node Name="SimpleQueryBase" Bounds="336,305,235,576" Id="R9Vhwb1rYoZOzefTMtiiu7">
-          <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="builtin">
+        <Node Name="SimpleQueryBase" Bounds="84,101,283,696" Id="R9Vhwb1rYoZOzefTMtiiu7">
+          <p:NodeReference LastCategoryFullName="Primitive" LastDependency="builtin">
             <Choice Kind="OperationDefinition" Name="Operation" />
           </p:NodeReference>
           <Patch Id="B54gvKHT898NYhFJsyK0Rf" ManuallySortedPins="true">
-            <Node Bounds="348,362,52,26" Id="CuQ4dcfSQDvQXQmEe89m1H">
-              <p:NodeReference LastCategoryFullName="RestSharp.RestClient" LastSymbolSource="RestSharp.dll">
+            <Node Bounds="96,140,65,26" Id="CuQ4dcfSQDvQXQmEe89m1H">
+              <p:NodeReference LastCategoryFullName="RestSharp.RestClient" LastDependency="RestSharp.dll" OverloadStrategy="AllPinsThatAreNotCommon">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <CategoryReference Kind="AssemblyCategory" Name="RestClient" />
                 <Choice Kind="OperationCallFlag" Name="Create" />
                 <PinReference Kind="InputPin" Name="Base Url">
-                  <p:DataTypeReference p:Type="TypeReference" LastCategoryFullName="System" LastSymbolSource="mscorlib.dll">
+                  <p:DataTypeReference p:Type="TypeReference" LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                     <Choice Kind="TypeFlag" Name="String" />
+                    <FullNameCategoryReference ID="System" />
+                    <AssemblyReference ID="System.Runtime.dll" />
                   </p:DataTypeReference>
                 </PinReference>
+                <PinReference Kind="InputPin" Name="Configure Rest Client" />
+                <PinReference Kind="InputPin" Name="Configure Default Headers" />
               </p:NodeReference>
               <Pin Id="LDSd7ZhvfdONO0Hkoyo7rq" Name="Base Url" Kind="InputPin" />
               <Pin Id="AXvlGmz4WRiOaoZ9ByWqmH" Name="Output" Kind="StateOutputPin" />
+              <Pin Id="NrtIJTIuLl9MUyA4DxYAJn" Name="Configure Rest Client" Kind="InputPin" />
+              <Pin Id="FHRJFg0s8j8LBI3m1YZn0I" Name="Configure Default Headers" Kind="InputPin" />
+              <Pin Id="Rj0Uvz2aPVDMKIJ5ZaXn8x" Name="Configure Serialization" Kind="InputPin" />
             </Node>
-            <Node Bounds="454,347,60,26" Id="UNAGxHU28imLpZnutz5dCh">
-              <p:NodeReference LastCategoryFullName="RestSharp.RestRequest" LastSymbolSource="RestSharp.dll">
+            <Node Bounds="183,220,60,26" Id="UNAGxHU28imLpZnutz5dCh">
+              <p:NodeReference LastCategoryFullName="RestSharp.RestRequest" LastDependency="RestSharp.dll" OverloadStrategy="UserSelectedPins">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <CategoryReference Kind="AssemblyCategory" Name="RestRequest" />
                 <Choice Kind="OperationCallFlag" Name="Create" />
                 <PinReference Kind="InputPin" Name="Method" />
+                <PinReference Kind="InputPin" Name="Resource">
+                  <p:DataTypeReference p:Type="TypeReference" LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
+                    <Choice Kind="TypeFlag" Name="String" />
+                    <FullNameCategoryReference ID="System" />
+                    <AssemblyReference ID="System.Runtime.dll" />
+                  </p:DataTypeReference>
+                </PinReference>
               </p:NodeReference>
+              <Pin Id="HFaMU9EtlGGPrHCPsvFIGH" Name="Resource" Kind="InputPin" />
               <Pin Id="LZceze6S3miQSbgmNl2u3f" Name="Method" Kind="InputPin" />
               <Pin Id="G1x8BhrK1gyQYeClKHb9EY" Name="Output" Kind="StateOutputPin" />
             </Node>
-            <ControlPoint Id="Tl7P3m5j7FyPd4SSNt6YUw" Bounds="421,323" />
-            <ControlPoint Id="QfJXk8CSRrDLDyGeSDF6IQ" Bounds="350,341" />
-            <Node Bounds="441,421,117,122" Id="BZ3jw1Y6Kz3MM0TLEINW8o">
-              <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="VL.CoreLib.dll">
+            <ControlPoint Id="Tl7P3m5j7FyPd4SSNt6YUw" Bounds="172,131" />
+            <ControlPoint Id="QfJXk8CSRrDLDyGeSDF6IQ" Bounds="98,119" />
+            <Node Bounds="170,315,150,128" Id="BZ3jw1Y6Kz3MM0TLEINW8o">
+              <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
                 <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
                 <Choice Kind="ApplicationStatefulRegion" Name="ForEach" />
                 <FullNameCategoryReference ID="Primitive" />
@@ -339,20 +376,26 @@
                 <Patch Id="O08UWJfYJfLQBsBeoxQbg8" Name="Create" ManuallySortedPins="true" />
                 <Patch Id="QiuILFfRfNjOzHDOvsSkcJ" Name="Update" ManuallySortedPins="true" />
                 <Patch Id="Fl4e9lx1QEDLNdILldMBEj" Name="Dispose" ManuallySortedPins="true" />
-                <Node Bounds="453,496,67,26" Id="BXuGIa9ThHWL3TaEugibhv">
-                  <p:NodeReference LastCategoryFullName="RestSharp.RestRequest" LastSymbolSource="RestSharp.dll">
+                <Node Bounds="182,396,126,26" Id="BXuGIa9ThHWL3TaEugibhv">
+                  <p:NodeReference LastCategoryFullName="RestSharp.RestRequestExtensions" LastDependency="RestSharp.dll" OverloadStrategy="AllPinsThatAreNotCommon">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                    <CategoryReference Kind="AssemblyCategory" Name="RestRequestExtensions" NeedsToBeDirectParent="true" />
                     <Choice Kind="OperationCallFlag" Name="AddHeader" />
-                    <CategoryReference Kind="AssemblyCategory" Name="RestRequest" NeedsToBeDirectParent="true" />
+                    <PinReference Kind="InputPin" Name="Value">
+                      <p:DataTypeReference p:Type="TypeReference" LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
+                        <Choice Kind="TypeFlag" Name="String" />
+                        <FullNameCategoryReference ID="System" />
+                        <AssemblyReference ID="System.Runtime.dll" />
+                      </p:DataTypeReference>
+                    </PinReference>
                   </p:NodeReference>
                   <Pin Id="S6nndnoiDYWQUg3RtxlVeY" Name="Input" Kind="StateInputPin" />
                   <Pin Id="Dzt0umylf15Lgm0mMjbhrg" Name="Name" Kind="InputPin" />
                   <Pin Id="S3bmwFOcvp3QBpKag7CXAM" Name="Value" Kind="InputPin" />
                   <Pin Id="Um5gPdR9V4WNoU9a7gBWLk" Name="Output" Kind="StateOutputPin" />
-                  <Pin Id="V8dJlmWEyZ2O68E1543nJu" Name="Result" Kind="OutputPin" />
                 </Node>
-                <Node Bounds="484,444,62,26" Id="RYh2Ys50j22N7zCnxaKs5b">
-                  <p:NodeReference LastCategoryFullName="Collections.Common.KeyValuePair" LastSymbolSource="VL.Collections.vl">
+                <Node Bounds="242,350,66,26" Id="RYh2Ys50j22N7zCnxaKs5b">
+                  <p:NodeReference LastCategoryFullName="Collections.Common.KeyValuePair" LastDependency="VL.Collections.vl">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                     <CategoryReference Kind="RecordType" Name="KeyValuePair" />
                     <Choice Kind="OperationCallFlag" Name="Split" />
@@ -362,28 +405,31 @@
                   <Pin Id="LpODVs1GKf8Pc6UJb4koP1" Name="Value" Kind="OutputPin" />
                 </Node>
               </Patch>
-              <ControlPoint Id="S9Im4uaWPotO3xFy31OEfS" Bounds="486,428" Alignment="Top" />
-              <ControlPoint Id="DzagQmsyDX7L8yVzIuJmz8" Bounds="455,537" Alignment="Bottom" />
-              <ControlPoint Id="DlwtNeqZyPHNU2tYYynzSP" Bounds="456,428" Alignment="Top" />
+              <ControlPoint Id="S9Im4uaWPotO3xFy31OEfS" Bounds="244,321" Alignment="Top" />
+              <ControlPoint Id="DzagQmsyDX7L8yVzIuJmz8" Bounds="184,437" Alignment="Bottom" />
+              <ControlPoint Id="DlwtNeqZyPHNU2tYYynzSP" Bounds="185,321" Alignment="Top" />
             </Node>
-            <ControlPoint Id="FsqMIw8S4A6MdvWfQ41qCi" Bounds="486,392" />
-            <Node Bounds="348,818,52,26" Id="IyF8KgxLAhRLQR8HfMtllN">
-              <p:NodeReference LastCategoryFullName="RestSharp.RestClient" LastSymbolSource="RestSharp.dll">
+            <ControlPoint Id="FsqMIw8S4A6MdvWfQ41qCi" Bounds="244,300" />
+            <Node Bounds="96,708,91,26" Id="IyF8KgxLAhRLQR8HfMtllN">
+              <p:NodeReference LastCategoryFullName="RestSharp.RestClientExtensions" LastDependency="RestSharp.dll" OverloadStrategy="AllPinsThatAreNotCommon">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                <CategoryReference Kind="AssemblyCategory" Name="RestClientExtensions" NeedsToBeDirectParent="true">
+                  <p:OuterCategoryReference Kind="AssemblyCategory" Name="RestSharp" NeedsToBeDirectParent="true" />
+                </CategoryReference>
                 <Choice Kind="OperationCallFlag" Name="Execute" />
-                <CategoryReference Kind="AssemblyCategory" Name="RestClient" NeedsToBeDirectParent="true" />
-                <PinReference Kind="OutputPin" Name="return">
-                  <p:DataTypeReference p:Type="TypeReference" LastCategoryFullName="RestSharp" LastSymbolSource="RestSharp.dll">
-                    <Choice Kind="TypeFlag" Name="IRestResponse" />
+                <PinReference Kind="OutputPin" Name="Result">
+                  <p:DataTypeReference p:Type="TypeReference" LastCategoryFullName="RestSharp" LastDependency="RestSharp.dll">
+                    <Choice Kind="TypeFlag" Name="RestResponse" />
+                    <FullNameCategoryReference ID="RestSharp" />
+                    <AssemblyReference ID="RestSharp.dll" />
                   </p:DataTypeReference>
                 </PinReference>
               </p:NodeReference>
               <Pin Id="PaVTtn76hUyP5npo4jBbyD" Name="Input" Kind="StateInputPin" />
               <Pin Id="Tgwt4ZlBSqlLnQ1A6dEXLV" Name="Request" Kind="InputPin" />
-              <Pin Id="LTaVzytrw6HL6LemaTGgdR" Name="Output" Kind="StateOutputPin" />
               <Pin Id="OzYaKEFngn8OF5q7BnBnfx" Name="Result" Kind="OutputPin" />
             </Node>
-            <ControlPoint Id="VelmPHW9kaRLeRRoMEm2Zv" Bounds="397,864" />
+            <ControlPoint Id="VelmPHW9kaRLeRRoMEm2Zv" Bounds="98,780" />
             <Link Id="NrupEQPG5EzLAhiDLTExGt" Ids="Tl7P3m5j7FyPd4SSNt6YUw,LZceze6S3miQSbgmNl2u3f" />
             <Link Id="RKETDy7KUbUOCoIRQoBzmn" Ids="VKJ1n7zj0GPOm00mR5lRf8,Tl7P3m5j7FyPd4SSNt6YUw" IsHidden="true" />
             <Link Id="UcCmyNmAcW9L2agQGIsva6" Ids="QfJXk8CSRrDLDyGeSDF6IQ,LDSd7ZhvfdONO0Hkoyo7rq" />
@@ -398,14 +444,13 @@
             <Link Id="GAu8bhpcYbSLERy4cxne36" Ids="AXvlGmz4WRiOaoZ9ByWqmH,PaVTtn76hUyP5npo4jBbyD" />
             <Link Id="HGyhB9oYoDUPqo4frFx1On" Ids="OzYaKEFngn8OF5q7BnBnfx,VelmPHW9kaRLeRRoMEm2Zv" />
             <Link Id="SI9gleXwytrNtAwkCfl3Nm" Ids="VelmPHW9kaRLeRRoMEm2Zv,KrVg4onPM2NPyg8q4WYAJz" IsHidden="true" />
-            <Link Id="PcZU0I7oLTPMGum3cMwycG" Ids="G1x8BhrK1gyQYeClKHb9EY,DlwtNeqZyPHNU2tYYynzSP" />
             <Link Id="EsJYubZla7OOSJ0JuJpxsS" Ids="DlwtNeqZyPHNU2tYYynzSP,S6nndnoiDYWQUg3RtxlVeY" />
-            <ControlPoint Id="Mt3oZKIEtNGMZ08sWAfCvT" Bounds="526,569" />
+            <ControlPoint Id="Mt3oZKIEtNGMZ08sWAfCvT" Bounds="246,460" />
             <Link Id="En2a9JdrWqrQbvrVTy88o2" Ids="K4bxQz9lEivPIRohg2D7M2,Mt3oZKIEtNGMZ08sWAfCvT" IsHidden="true" />
             <Link Id="DzuDPbVFzzTMlDDOZVLkHJ" Ids="Mt3oZKIEtNGMZ08sWAfCvT,EkfkEdKa92NLlTi3sEFsWj" />
             <Pin Id="Cs6f76aXgH1PYznw1sZsGE" Name="URL" Kind="InputPin" Bounds="432,277" />
             <Pin Id="HlZDA5dt5v6OQq1s10NG2u" Name="Headers" Kind="InputPin">
-              <p:TypeAnnotation>
+              <p:TypeAnnotation LastCategoryFullName="Collections" LastDependency="VL.CoreLib.vl">
                 <Choice Kind="TypeFlag" Name="Spread" />
                 <p:TypeArguments>
                   <TypeReference>
@@ -423,14 +468,14 @@
               </p:TypeAnnotation>
             </Pin>
             <Pin Id="K4bxQz9lEivPIRohg2D7M2" Name="Body" Kind="InputPin" Bounds="685,550">
-              <p:TypeAnnotation>
+              <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                 <Choice Kind="TypeFlag" Name="String" />
               </p:TypeAnnotation>
             </Pin>
             <Pin Id="VKJ1n7zj0GPOm00mR5lRf8" Name="Method" Kind="InputPin" Bounds="481,362" />
             <Pin Id="KrVg4onPM2NPyg8q4WYAJz" Name="Result" Kind="OutputPin" Bounds="404,447" />
-            <Node Bounds="441,697,100,83" Id="MuBmFWqOPaVPKMmYBcrUdY">
-              <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="VL.CoreLib.dll">
+            <Node Bounds="170,584,185,114" Id="MuBmFWqOPaVPKMmYBcrUdY">
+              <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
                 <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
                 <Choice Kind="ApplicationStatefulRegion" Name="If" />
                 <FullNameCategoryReference ID="Primitive" />
@@ -439,28 +484,36 @@
               <Patch Id="UyzLfrFYB1EPC1lGGcV22W" ManuallySortedPins="true">
                 <Patch Id="MJ0QQ6k1XS4P0Et9lBcGYV" Name="Create" ManuallySortedPins="true" />
                 <Patch Id="B7KEsop17OJPckX4c5Ifbo" Name="Then" ManuallySortedPins="true" />
-                <Node Bounds="453,727,76,26" Id="NLPosUPHizqP6eZdN4NkK5">
-                  <p:NodeReference LastCategoryFullName="RestSharp.RestRequest" LastSymbolSource="RestSharp.dll">
+                <Node Bounds="182,644,130,26" Id="NLPosUPHizqP6eZdN4NkK5">
+                  <p:NodeReference LastCategoryFullName="RestSharp.RestRequestExtensions" LastDependency="RestSharp.dll" OverloadStrategy="AllPinsThatAreNotCommon">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                    <CategoryReference Kind="AssemblyCategory" Name="RestRequest" NeedsToBeDirectParent="true" />
                     <Choice Kind="OperationCallFlag" Name="AddJsonBody" />
+                    <PinReference Kind="InputPin" Name="Obj" />
                   </p:NodeReference>
                   <Pin Id="LnvrI94xKueMJ8yAQ0eUPt" Name="Input" Kind="StateInputPin" />
                   <Pin Id="EkfkEdKa92NLlTi3sEFsWj" Name="Obj" Kind="InputPin" />
                   <Pin Id="PlMyWDkWyLkNmeXIXSWSCZ" Name="Output" Kind="StateOutputPin" />
-                  <Pin Id="GxP9pDnEpcpOF9laN7YClM" Name="Result" Kind="OutputPin" />
+                  <Pin Id="GZttJTgeMO9PAIUBfVYO4p" Name="Content Type" Kind="InputPin" />
+                </Node>
+                <Node Bounds="307,610,36,19" Id="L6eBBaII0sQMqFQPXQ8uSY">
+                  <p:NodeReference LastCategoryFullName="RestSharp.ContentType" LastDependency="RestSharp.dll">
+                    <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                    <CategoryReference Kind="AssemblyCategory" Name="ContentType" />
+                    <Choice Kind="OperationCallFlag" Name="Json" />
+                  </p:NodeReference>
+                  <Pin Id="S5yEolsGbclLR48LVMt14G" Name="Json" Kind="OutputPin" />
                 </Node>
               </Patch>
-              <ControlPoint Id="CS85I54HMepO1s7naOPC0s" Bounds="455,775" Alignment="Bottom" />
-              <ControlPoint Id="CTsftkveGtFMQlbsMGrkCQ" Bounds="455,704" Alignment="Top" />
+              <ControlPoint Id="CS85I54HMepO1s7naOPC0s" Bounds="184,692" Alignment="Bottom" />
+              <ControlPoint Id="CTsftkveGtFMQlbsMGrkCQ" Bounds="184,590" Alignment="Top" />
             </Node>
             <Link Id="CHEspskWaKdO47JMDdMNeK" Ids="CTsftkveGtFMQlbsMGrkCQ,CS85I54HMepO1s7naOPC0s" IsFeedback="true" />
             <Link Id="BPqKDKg0BWSQQpKxj7ZF4g" Ids="PlMyWDkWyLkNmeXIXSWSCZ,CS85I54HMepO1s7naOPC0s" />
             <Link Id="FvwHxh5ENABM5jZaHm7yGu" Ids="CS85I54HMepO1s7naOPC0s,Tgwt4ZlBSqlLnQ1A6dEXLV" />
             <Link Id="PCLvsd73chFP9u96sqtV3T" Ids="DzagQmsyDX7L8yVzIuJmz8,CTsftkveGtFMQlbsMGrkCQ" />
             <Link Id="QYH3kgRwIdWLZFaEP396Dy" Ids="CTsftkveGtFMQlbsMGrkCQ,LnvrI94xKueMJ8yAQ0eUPt" />
-            <Node Bounds="419,575,27,19" Id="UURtFCdcVnKOYQ3hJ7yPXs">
-              <p:NodeReference LastCategoryFullName="RestSharp.Method" LastSymbolSource="RestSharp.dll">
+            <Node Bounds="170,475,27,19" Id="UURtFCdcVnKOYQ3hJ7yPXs">
+              <p:NodeReference LastCategoryFullName="RestSharp.Method" LastDependency="RestSharp.dll">
                 <FullNameCategoryReference ID="RestSharp.Method" />
                 <Choice Kind="OperationCallFlag" Name="!=" />
               </p:NodeReference>
@@ -470,8 +523,8 @@
             </Node>
             <Link Id="FwCGInLVvSJNiFyooXkhv5" Ids="Tl7P3m5j7FyPd4SSNt6YUw,Nt6ooApFtEzOgcbkKvrCNp" />
             <Link Id="MHbuNXEAw9dQJ8dZ5gxVOO" Ids="CFX3BNlVVRILkSZlERAFgh,IUXh4ONn02NN59VXyOzB0x" />
-            <Node Bounds="471,595,81,19" Id="Gs4z7jL083cMCubHI4drKM">
-              <p:NodeReference LastCategoryFullName="Primitive.String" LastSymbolSource="CoreLibBasics.vl">
+            <Node Bounds="222,483,81,19" Id="Gs4z7jL083cMCubHI4drKM">
+              <p:NodeReference LastCategoryFullName="Primitive.String" LastDependency="CoreLibBasics.vl">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <Choice Kind="OperationCallFlag" Name="IsNullOrEmpty" />
               </p:NodeReference>
@@ -479,8 +532,8 @@
               <Pin Id="G0Sp3e8AprALquNkdZiQin" Name="Result" Kind="OutputPin" />
             </Node>
             <Link Id="KZ09kA5EL2VLSKeese0APm" Ids="Mt3oZKIEtNGMZ08sWAfCvT,UdLlsvq9bCDNgcGjIJLhf6" />
-            <Node Bounds="471,622,37,19" Id="OtIfKBcy0iuLNcdNpg1LSY">
-              <p:NodeReference LastCategoryFullName="Primitive.Boolean" LastSymbolSource="CoreLibBasics.vl">
+            <Node Bounds="222,510,37,19" Id="OtIfKBcy0iuLNcdNpg1LSY">
+              <p:NodeReference LastCategoryFullName="Primitive.Boolean" LastDependency="CoreLibBasics.vl">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <Choice Kind="OperationCallFlag" Name="NOT" />
               </p:NodeReference>
@@ -488,8 +541,8 @@
               <Pin Id="Utx1mf04nMnOHRuhpQsXbV" Name="Output" Kind="StateOutputPin" />
             </Node>
             <Link Id="MSCqdU9BhVtLvXO1Xc7OCn" Ids="G0Sp3e8AprALquNkdZiQin,O0a21xeRwIbPgEKjfxSybH" />
-            <Node Bounds="419,656,57,19" Id="A7RQ9cm1OrzMDODJnP42n9">
-              <p:NodeReference LastCategoryFullName="Primitive.Boolean" LastSymbolSource="CoreLibBasics.vl">
+            <Node Bounds="170,540,57,19" Id="A7RQ9cm1OrzMDODJnP42n9">
+              <p:NodeReference LastCategoryFullName="Primitive.Boolean" LastDependency="CoreLibBasics.vl">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <Choice Kind="OperationCallFlag" Name="AND" />
               </p:NodeReference>
@@ -499,6 +552,23 @@
             </Node>
             <Link Id="FEH9a3mniCCMF9pKkm4zeo" Ids="N2GXhMrOhygPHJqiix9Z7l,GOgnl7IpNGBQTlO68bFz2s" />
             <Link Id="DxRLXzhirsUOwxW6YqHpH2" Ids="Utx1mf04nMnOHRuhpQsXbV,D6MNRQRYgThN2hbSXEd1rm" />
+            <Link Id="PRzS0QMVKESOJ33zHALIR6" Ids="S5yEolsGbclLR48LVMt14G,GZttJTgeMO9PAIUBfVYO4p" />
+            <ControlPoint Id="EOFFGPcgrsNMqtxisOBS3W" Bounds="248,140" />
+            <Pin Id="GtqricoNqdEPVyaHsqchr2" Name="Timeout" Kind="InputPin" />
+            <Link Id="VT9inrcwT3HN885To9iybp" Ids="GtqricoNqdEPVyaHsqchr2,EOFFGPcgrsNMqtxisOBS3W" IsHidden="true" />
+            <Node Bounds="183,260,68,26" Id="A68rKLEvvI4M0ZiJB2ETCw">
+              <p:NodeReference LastCategoryFullName="RestSharp.RestRequest" LastDependency="RestSharp.dll">
+                <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+                <CategoryReference Kind="AssemblyCategory" Name="RestRequest" />
+                <Choice Kind="OperationCallFlag" Name="SetTimeout" />
+              </p:NodeReference>
+              <Pin Id="UCDzrV628oVPRck1iO6bgd" Name="Input" Kind="StateInputPin" />
+              <Pin Id="EDbmNR0Mib9OBR1JTMWV8w" Name="Value" Kind="InputPin" />
+              <Pin Id="HVFj3fKgcUEM9ptJTzuw5D" Name="Output" Kind="StateOutputPin" />
+            </Node>
+            <Link Id="JAnMrPMaA3fPUkThx08hzy" Ids="G1x8BhrK1gyQYeClKHb9EY,UCDzrV628oVPRck1iO6bgd" />
+            <Link Id="EQUUznyd4BPM7pI3sW8E3H" Ids="HVFj3fKgcUEM9ptJTzuw5D,DlwtNeqZyPHNU2tYYynzSP" />
+            <Link Id="UINC64R9NzLK9cp1LdQ5lm" Ids="EOFFGPcgrsNMqtxisOBS3W,EDbmNR0Mib9OBR1JTMWV8w" />
           </Patch>
         </Node>
         <!--
@@ -506,13 +576,13 @@
     ************************ RetrieveBasicResponseData ************************
 
 -->
-        <Node Name="RetrieveBasicResponseData" Bounds="824,403,592,271" Id="ETHGvPh5wvEMBN9GBVo0BB">
-          <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="builtin">
+        <Node Name="RetrieveBasicResponseData" Bounds="487,113,654,274" Id="ETHGvPh5wvEMBN9GBVo0BB">
+          <p:NodeReference LastCategoryFullName="Primitive" LastDependency="builtin">
             <Choice Kind="OperationDefinition" Name="Operation" />
           </p:NodeReference>
           <Patch Id="S6jxPJggoGPNg2hxNnnOJU">
-            <Node Bounds="847,494,510,128" Id="Kydm6PZaY35MvQo3O5zWK9">
-              <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="VL.CoreLib.dll">
+            <Node Bounds="510,205,571,133" Id="Kydm6PZaY35MvQo3O5zWK9">
+              <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
                 <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
                 <Choice Kind="ApplicationStatefulRegion" Name="If" />
                 <FullNameCategoryReference ID="Primitive" />
@@ -521,50 +591,48 @@
               <Patch Id="LeBGYQX3PiTOO5VL71o6z1" ManuallySortedPins="true">
                 <Patch Id="AtNdyz1pInNP8ymtZBqzph" Name="Create" ManuallySortedPins="true" />
                 <Patch Id="EjxtZzjCKXVLOcWbWnqqey" Name="Then" ManuallySortedPins="true" />
-                <Node Bounds="859,520,68,26" Id="KMiQRHlTIx2QDLzfkgUut6">
-                  <p:NodeReference LastCategoryFullName="RestSharp.IRestResponse" LastSymbolSource="RestSharp.dll">
+                <Node Bounds="522,230,82,26" Id="KMiQRHlTIx2QDLzfkgUut6">
+                  <p:NodeReference LastCategoryFullName="RestSharp.RestResponseBase" LastDependency="RestSharp.dll">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                    <CategoryReference Kind="AssemblyCategory" Name="IRestResponse" />
+                    <CategoryReference Kind="AssemblyCategory" Name="RestResponseBase" NeedsToBeDirectParent="true" />
                     <Choice Kind="OperationCallFlag" Name="Content" />
                   </p:NodeReference>
                   <Pin Id="ELKbZv7vjK6LIXNIcp9WD9" Name="Input" Kind="StateInputPin" />
                   <Pin Id="Tz0NYKJPIwpPfATsnIlLbR" Name="Output" Kind="StateOutputPin" />
                   <Pin Id="EbxauKRKzrKPpI7hXy2J5g" Name="Content" Kind="OutputPin" />
                 </Node>
-                <Node Bounds="1036,520,68,26" Id="G06p0EbzBRON6esP2QaiVz">
-                  <p:NodeReference LastCategoryFullName="RestSharp.IRestResponse" LastSymbolSource="RestSharp.dll">
+                <Node Bounds="744,230,82,26" Id="G06p0EbzBRON6esP2QaiVz">
+                  <p:NodeReference LastCategoryFullName="RestSharp.RestResponseBase" LastDependency="RestSharp.dll">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                    <CategoryReference Kind="AssemblyCategory" Name="IRestResponse" />
+                    <CategoryReference Kind="AssemblyCategory" Name="RestResponseBase" NeedsToBeDirectParent="true" />
                     <Choice Kind="OperationCallFlag" Name="StatusCode" />
                   </p:NodeReference>
                   <Pin Id="PJaLMGdVRpsNBS3NWQsB6R" Name="Input" Kind="StateInputPin" />
                   <Pin Id="Fskaw02Y7ynMsC62hBU4ib" Name="Output" Kind="StateOutputPin" />
                   <Pin Id="VPIW1Noawh8NkXE9ddYNMn" Name="Status Code" Kind="OutputPin" />
                 </Node>
-                <Node Bounds="1125,520,96,26" Id="H1OgffAXjv2Myw18u1sieQ">
-                  <p:NodeReference LastCategoryFullName="RestSharp.IRestResponse" LastSymbolSource="RestSharp.dll">
+                <Node Bounds="855,230,96,26" Id="H1OgffAXjv2Myw18u1sieQ">
+                  <p:NodeReference LastCategoryFullName="RestSharp.RestResponseBase" LastDependency="RestSharp.dll">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                    <CategoryReference Kind="AssemblyCategory" Name="IRestResponse" />
+                    <CategoryReference Kind="AssemblyCategory" Name="RestResponseBase" NeedsToBeDirectParent="true" />
                     <Choice Kind="OperationCallFlag" Name="StatusDescription" />
                   </p:NodeReference>
                   <Pin Id="R1h3v1DLxc8QaXpcR03KSy" Name="Input" Kind="StateInputPin" />
                   <Pin Id="KT4GAVlFcqiPmcHIeLZEPn" Name="Output" Kind="StateOutputPin" />
                   <Pin Id="Vey5zPVneeVPlziyswktbN" Name="Status Description" Kind="OutputPin" />
                 </Node>
-                <Node Bounds="1267,520,71,26" Id="SmKYpFrRkD5NyJkU7UCs5f">
-                  <p:NodeReference LastCategoryFullName="RestSharp.IRestResponse" LastSymbolSource="RestSharp.dll">
+                <Node Bounds="980,230,82,26" Id="SmKYpFrRkD5NyJkU7UCs5f">
+                  <p:NodeReference LastCategoryFullName="RestSharp.RestResponseBase" LastDependency="RestSharp.dll">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                    <CategoryReference Kind="AssemblyCategory" Name="IRestResponse" />
                     <Choice Kind="OperationCallFlag" Name="IsSuccessful" />
                   </p:NodeReference>
                   <Pin Id="Ku6J0zGWKJmPUxmRSpFoom" Name="Input" Kind="StateInputPin" />
                   <Pin Id="CFLjV4QqIPULyi9ih3aEO3" Name="Output" Kind="StateOutputPin" />
                   <Pin Id="S8MDYecHQoQNk7npkP4kPO" Name="Is Successful" Kind="OutputPin" />
                 </Node>
-                <Node Bounds="944,520,68,26" Id="URK3lDGE9TYPz4PEqSk9ud">
-                  <p:NodeReference LastCategoryFullName="RestSharp.IRestResponse" LastSymbolSource="RestSharp.dll">
+                <Node Bounds="633,230,82,26" Id="URK3lDGE9TYPz4PEqSk9ud">
+                  <p:NodeReference LastCategoryFullName="RestSharp.RestResponseBase" LastDependency="RestSharp.dll">
                     <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
-                    <CategoryReference Kind="AssemblyCategory" Name="IRestResponse" />
                     <Choice Kind="OperationCallFlag" Name="RawBytes" />
                   </p:NodeReference>
                   <Pin Id="M2hxE1ZiGwuLs0yv1ei0tu" Name="Input" Kind="StateInputPin" />
@@ -572,19 +640,19 @@
                   <Pin Id="NZDcTgBmDS5Ltrs9pNyFBw" Name="Raw Bytes" Kind="OutputPin" />
                 </Node>
               </Patch>
-              <ControlPoint Id="Q2WHqhqw2ByOPtzELH1jIh" Bounds="924,616" Alignment="Bottom" />
-              <ControlPoint Id="VI1aespcLi0LSNPGE1bcou" Bounds="924,500" Alignment="Top" />
-              <ControlPoint Id="K4rtxhvk8DrNupM29C6oi6" Bounds="1101,616" Alignment="Bottom" />
-              <ControlPoint Id="NnRTHnNQtYXNpAA73LOAU2" Bounds="1011,500" Alignment="Top" />
-              <ControlPoint Id="V58sF7OyyuoLDWBv0k2ZSt" Bounds="1218,616" Alignment="Bottom" />
-              <ControlPoint Id="HMrJLzVbHolP4jLVH12MXj" Bounds="1129,500" Alignment="Top" />
-              <ControlPoint Id="DzALnvEQvm7MXiTM0JAnR3" Bounds="1335,616" Alignment="Bottom" />
-              <ControlPoint Id="BvDrRjdOPJkLOP3D8LAZ8I" Bounds="1245,500" Alignment="Top" />
-              <ControlPoint Id="TzRnTvT658XNCE3MvMHsLd" Bounds="1009,616" Alignment="Bottom" />
-              <ControlPoint Id="GWMfl6L9C1pMHZi6N1jIVv" Bounds="1009,500" Alignment="Top" />
+              <ControlPoint Id="Q2WHqhqw2ByOPtzELH1jIh" Bounds="601,332" Name="C" Alignment="Bottom" />
+              <ControlPoint Id="VI1aespcLi0LSNPGE1bcou" Bounds="587,211" Name="C" Alignment="Top" />
+              <ControlPoint Id="K4rtxhvk8DrNupM29C6oi6" Bounds="823,332" Name="SC" Alignment="Bottom" />
+              <ControlPoint Id="NnRTHnNQtYXNpAA73LOAU2" Bounds="817,211" Name="SC" Alignment="Top" />
+              <ControlPoint Id="V58sF7OyyuoLDWBv0k2ZSt" Bounds="948,332" Name="SD" Alignment="Bottom" />
+              <ControlPoint Id="HMrJLzVbHolP4jLVH12MXj" Bounds="941,211" Name="SD" Alignment="Top" />
+              <ControlPoint Id="DzALnvEQvm7MXiTM0JAnR3" Bounds="1060,332" Name="IS" Alignment="Bottom" />
+              <ControlPoint Id="BvDrRjdOPJkLOP3D8LAZ8I" Bounds="1060,211" Name="IS" Alignment="Top" />
+              <ControlPoint Id="TzRnTvT658XNCE3MvMHsLd" Bounds="712,332" Name="RB" Alignment="Bottom" />
+              <ControlPoint Id="GWMfl6L9C1pMHZi6N1jIVv" Bounds="712,211" Name="RB" Alignment="Top" />
             </Node>
-            <Node Bounds="847,462,65,19" Id="QBwGqju6S49OSVqsZRn7Ox">
-              <p:NodeReference LastCategoryFullName="Primitive.Object" LastSymbolSource="CoreLibBasics.vl">
+            <Node Bounds="510,172,65,19" Id="QBwGqju6S49OSVqsZRn7Ox">
+              <p:NodeReference LastCategoryFullName="Primitive.Object" LastDependency="CoreLibBasics.vl">
                 <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                 <Choice Kind="OperationCallFlag" Name="IsAssigned" />
               </p:NodeReference>
@@ -601,30 +669,26 @@
             <Link Id="GfKw5VlJiIsOVEa84TwlTK" Ids="BvDrRjdOPJkLOP3D8LAZ8I,DzALnvEQvm7MXiTM0JAnR3" IsFeedback="true" />
             <Link Id="DfUy4vwpQE3PmrRBVJpdFu" Ids="S8MDYecHQoQNk7npkP4kPO,DzALnvEQvm7MXiTM0JAnR3" />
             <Link Id="QV8hAsuydGUOERnKlqU2Y8" Ids="DyBlm4XtLMnLGly5G8jQpJ,BLxpdNbRPLXOhYhiJxGx0Y" />
-            <ControlPoint Id="SsECQWCpCNGLNz9ZsRzBNb" Bounds="849,421" />
+            <ControlPoint Id="SsECQWCpCNGLNz9ZsRzBNb" Bounds="524,131" />
             <Link Id="HnwsHFgTb28QPTOLfuhlnw" Ids="SsECQWCpCNGLNz9ZsRzBNb,RBTQSpfV7C0Oz6ml9GAx4H" />
             <Link Id="BomklEbSRyIO7Ijb7zXesh" Ids="BTVd0qm3Z5mMDHbZR32sPr,SsECQWCpCNGLNz9ZsRzBNb" IsHidden="true" />
             <Link Id="KTpCeInM7LkNIkej0BFumX" Ids="SsECQWCpCNGLNz9ZsRzBNb,ELKbZv7vjK6LIXNIcp9WD9" />
-            <Link Id="JMnyp7gQq2tNuSbPrYhhFr" Ids="SsECQWCpCNGLNz9ZsRzBNb,PJaLMGdVRpsNBS3NWQsB6R" />
-            <Link Id="HXqW8VfUXmILZSDkChsCgk" Ids="SsECQWCpCNGLNz9ZsRzBNb,R1h3v1DLxc8QaXpcR03KSy" />
-            <Link Id="Tg2soGuHhcRPpazUYkwTln" Ids="SsECQWCpCNGLNz9ZsRzBNb,Ku6J0zGWKJmPUxmRSpFoom" />
             <Link Id="HsMXeJx1hKUO1CgGXQshpr" Ids="Q2WHqhqw2ByOPtzELH1jIh,QevPooG9C2yQday12InGsO" />
-            <ControlPoint Id="QevPooG9C2yQday12InGsO" Bounds="924,657" />
+            <ControlPoint Id="QevPooG9C2yQday12InGsO" Bounds="601,370" />
             <Link Id="MCcoVK1Bs7LLaPsT9Rmeal" Ids="QevPooG9C2yQday12InGsO,Kt3Y9yn8tENM6zgMwKXJfO" IsHidden="true" />
             <Link Id="LdPv7T0PPeeOxrBHORvPqT" Ids="K4rtxhvk8DrNupM29C6oi6,HnPAvt91vVzL1rZNKgWRt3" />
-            <ControlPoint Id="HnPAvt91vVzL1rZNKgWRt3" Bounds="1102,657" />
+            <ControlPoint Id="HnPAvt91vVzL1rZNKgWRt3" Bounds="824,370" />
             <Link Id="Quc6EqOSoOzNl2tgX7eWJ7" Ids="HnPAvt91vVzL1rZNKgWRt3,AAG0cFpy9cmOIUPGa205BQ" IsHidden="true" />
             <Link Id="Qpd72d8ON3ZP35rZqK8bP6" Ids="V58sF7OyyuoLDWBv0k2ZSt,JzeCGsV9TGnPjChnUkfmlU" />
-            <ControlPoint Id="JzeCGsV9TGnPjChnUkfmlU" Bounds="1218,657" />
+            <ControlPoint Id="JzeCGsV9TGnPjChnUkfmlU" Bounds="948,361" />
             <Link Id="RSP1P1vjDDEOqejMue8KP0" Ids="JzeCGsV9TGnPjChnUkfmlU,Dnq8luTn7gfMmcZ2TiVfHY" IsHidden="true" />
             <Link Id="VeM7kjYO7VcNk9vn4xiwwx" Ids="DzALnvEQvm7MXiTM0JAnR3,ISTOQLCypzbLnrsjLMk83o" />
-            <ControlPoint Id="ISTOQLCypzbLnrsjLMk83o" Bounds="1335,657" />
+            <ControlPoint Id="ISTOQLCypzbLnrsjLMk83o" Bounds="1060,370" />
             <Link Id="IDPBlNZX1SlPGDH0HwjUIh" Ids="ISTOQLCypzbLnrsjLMk83o,BCBaOdhQ9w9MzeznMqZAW0" IsHidden="true" />
-            <Link Id="A4t9EDmlomaLWxRuKQ81dj" Ids="SsECQWCpCNGLNz9ZsRzBNb,M2hxE1ZiGwuLs0yv1ei0tu" />
             <Link Id="OHXCqfgiG4KO8V1xrucHQx" Ids="GWMfl6L9C1pMHZi6N1jIVv,TzRnTvT658XNCE3MvMHsLd" IsFeedback="true" />
             <Link Id="IMKxR6pkmf8QdY0kxZslBB" Ids="NZDcTgBmDS5Ltrs9pNyFBw,TzRnTvT658XNCE3MvMHsLd" />
             <Link Id="UtBp37jYx2jNMfVmKCro3Q" Ids="TzRnTvT658XNCE3MvMHsLd,VIePsk98IVfOpQolX4edVP" />
-            <ControlPoint Id="VIePsk98IVfOpQolX4edVP" Bounds="1009,657" />
+            <ControlPoint Id="VIePsk98IVfOpQolX4edVP" Bounds="712,370" />
             <Link Id="SiNdxoAHwxkLDkgOflh36A" Ids="VIePsk98IVfOpQolX4edVP,Cf4mwquP9AuOqOs2BqXiLo" IsHidden="true" />
             <Pin Id="BTVd0qm3Z5mMDHbZR32sPr" Name="Response" Kind="InputPin" Bounds="873,448" />
             <Pin Id="Kt3Y9yn8tENM6zgMwKXJfO" Name="Content" Kind="OutputPin" Bounds="924,620" />
@@ -632,6 +696,10 @@
             <Pin Id="AAG0cFpy9cmOIUPGa205BQ" Name="Status Code" Kind="OutputPin" Bounds="1010,620" />
             <Pin Id="Dnq8luTn7gfMmcZ2TiVfHY" Name="Status Description" Kind="OutputPin" Bounds="1128,621" />
             <Pin Id="BCBaOdhQ9w9MzeznMqZAW0" Name="Is Successful" Kind="OutputPin" Bounds="1245,624" />
+            <Link Id="Dn9oLf8M3EzLV0Ph8oWUCG" Ids="Tz0NYKJPIwpPfATsnIlLbR,M2hxE1ZiGwuLs0yv1ei0tu" />
+            <Link Id="BmavQkJADwJMFsBUe7vpBw" Ids="AAlvAHZPSRmMkeGft2EJ2w,PJaLMGdVRpsNBS3NWQsB6R" />
+            <Link Id="AwVrkS2wQH0PCHh7XOQlBj" Ids="Fskaw02Y7ynMsC62hBU4ib,R1h3v1DLxc8QaXpcR03KSy" />
+            <Link Id="EORKfLf7dqqPVLDomF99wX" Ids="KT4GAVlFcqiPmcHIeLZEPn,Ku6J0zGWKJmPUxmRSpFoom" />
           </Patch>
         </Node>
       </Canvas>
@@ -640,38 +708,40 @@
     ************************ HttpStatusCode ************************
 
 -->
-      <Node Name="HttpStatusCode" Bounds="556,317" Id="GwictnDpmajNkwNsrv8pgK">
+      <Node Name="HttpStatusCode" Bounds="418,100" Id="GwictnDpmajNkwNsrv8pgK">
         <p:NodeReference>
           <Choice Kind="ForwardRecordDefinition" Name="Immutable Forward" />
           <FullNameCategoryReference ID="Primitive" />
         </p:NodeReference>
-        <p:TypeAnnotation LastCategoryFullName="System.Net" LastSymbolSource="System.dll">
+        <p:TypeAnnotation LastCategoryFullName="System.Net" LastDependency="System.dll">
           <Choice Kind="TypeFlag" Name="HttpStatusCode" />
         </p:TypeAnnotation>
         <Patch Id="BVj4kevZxt2LhZWUoaYX8r">
-          <Canvas Id="SaI52fBeN5JNd32dOIHvm6" BordersChecked="false" CanvasType="Group" />
+          <Canvas Id="SaI52fBeN5JNd32dOIHvm6" CanvasType="Group" />
           <ProcessDefinition Id="DIpKJNxIqAtOk0PrHGhGJL" IsHidden="true" />
         </Patch>
       </Node>
-      <Canvas Id="BR5FH4vuX2ZMpWXYVx5Doq" Name="Advanced" Position="313,431">
+      <Canvas Id="BR5FH4vuX2ZMpWXYVx5Doq" Name="Advanced" Position="127,261">
         <!--
 
     ************************ Request (Async Reactive) ************************
 
 -->
-        <Node Name="Request (Async Reactive)" Bounds="341,314" Id="Qv1aJvtdoedNxc5nGaWFSY">
-          <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="builtin">
+        <Node Name="Request (Async Reactive)" Bounds="97,104" Id="Qv1aJvtdoedNxc5nGaWFSY">
+          <p:NodeReference LastCategoryFullName="Primitive" LastDependency="builtin">
             <Choice Kind="ContainerDefinition" Name="Process" />
           </p:NodeReference>
           <Patch Id="Vnz6eA1GrQULrLG6WBzNrV">
             <Canvas Id="UAZlwHLvWpvOkM809m9nA3" CanvasType="Group">
-              <Node Bounds="277,306,190,134" Id="TZuUldwc84FLAw89kRz08C">
-                <p:NodeReference LastCategoryFullName="Reactive" LastSymbolSource="VL.Reactive.vl">
+              <Node Bounds="87,216,189,115" Id="TZuUldwc84FLAw89kRz08C">
+                <p:NodeReference LastCategoryFullName="Reactive" LastDependency="VL.Reactive.vl">
                   <Choice Kind="ProcessAppFlag" Name="AsyncTask" />
                   <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
                 </p:NodeReference>
+                <Pin Id="Otb8jMRoDI0PSY4E8X60hJ" Name="Node Context" Kind="InputPin" IsHidden="true" />
                 <Pin Id="JULKREWW3MaPvcvfhLJbXC" Name="Trigger" Kind="InputPin" />
                 <Pin Id="TEw4bwuWW1xQKqvmIgcaWC" Name="Abort" Kind="InputPin" />
+                <Pin Id="LcBfcLZIbzNMujRfOtgkd8" Name="Output" Kind="OutputPin" IsHidden="true" />
                 <Pin Id="SOkWHR9syezLSYKXXXhOMg" Name="Result" Kind="OutputPin" />
                 <Pin Id="BEDMmKdZJ5NNS445NEcz1b" Name="In Progress" Kind="OutputPin" />
                 <Patch Id="SuGSXhLgGotOkOJFmDmk8y" ManuallySortedPins="true">
@@ -680,10 +750,10 @@
                     <Pin Id="NfKgUrKXMjXPtdRmWuuJdZ" Name="Input 1" Kind="InputPin" />
                     <Pin Id="RVcEmztPczFPmWLJRPTeRk" Name="Output" Kind="OutputPin" />
                   </Patch>
-                  <ControlPoint Id="JkjWLLz1x4JPuLNCzZ79Cn" Bounds="411,325" />
-                  <ControlPoint Id="EBVJT88sdn6NQrIRcQBv47" Bounds="291,433" />
-                  <Node Bounds="290,329,65,19" Id="NrJDQw5bOYIPm50mjNbPfN">
-                    <p:NodeReference>
+                  <ControlPoint Id="JkjWLLz1x4JPuLNCzZ79Cn" Bounds="220,235" />
+                  <ControlPoint Id="EBVJT88sdn6NQrIRcQBv47" Bounds="101,324" />
+                  <Node Bounds="99,239,94,19" Id="NrJDQw5bOYIPm50mjNbPfN">
+                    <p:NodeReference LastCategoryFullName="IO.HTTP" LastDependency="VL.SimpleHTTP.vl">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <Choice Kind="OperationCallFlag" Name="SimpleQueryBase" />
                     </p:NodeReference>
@@ -692,32 +762,36 @@
                     <Pin Id="QLFvFZiOModM572Am4eklx" Name="Body" Kind="InputPin" />
                     <Pin Id="SUZBGLBtereM6qSpELHkqd" Name="Method" Kind="InputPin" />
                     <Pin Id="MfqMw2r2PTzL194NjnMpCQ" Name="Result" Kind="OutputPin" />
+                    <Pin Id="Njl0tFuxFmJOK6rv7eoBKp" Name="Timeout" Kind="InputPin" />
                   </Node>
-                  <Node Bounds="289,379,67,26" Id="EkKbGtnBAi9NYN9qulGuU6">
-                    <p:NodeReference LastCategoryFullName="IO.HTTP.ResponseData" LastSymbolSource="VL.SimpleHTTP.vl">
+                  <Node Bounds="99,270,67,26" Id="EkKbGtnBAi9NYN9qulGuU6">
+                    <p:NodeReference LastCategoryFullName="IO.HTTP.ResponseData" LastDependency="VL.SimpleHTTP.vl">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <CategoryReference Kind="RecordType" Name="ResponseData" />
                       <Choice Kind="OperationCallFlag" Name="Create" />
                     </p:NodeReference>
+                    <Pin Id="EtuoPutL3DyMeNcSf4pvCk" Name="Node Context" Kind="InputPin" IsHidden="true" />
                     <Pin Id="U9YFPSa7VZaNITRewn38nj" Name="Response" Kind="InputPin" />
                     <Pin Id="Iec7Wm3x4mTLHkJttt8mVH" Name="Output" Kind="StateOutputPin" />
                   </Node>
                 </Patch>
               </Node>
-              <ControlPoint Id="PDNcNVMPAmsNmaYagEnhEn" Bounds="350,241" />
-              <ControlPoint Id="TTSisu8Z8AkL5ZiRG6oXGQ" Bounds="273,249" />
-              <ControlPoint Id="RDZWSD37nxYQKq5iIi9Fq5" Bounds="424,248" />
-              <ControlPoint Id="LO4D5k5wr24N0s7ypFWJq5" Bounds="197,239" />
-              <ControlPoint Id="MaCEAzBuExXNaRKjzQ7CsL" Bounds="518,256" />
-              <ControlPoint Id="NayADq5zYezOXN0dX6GzFX" Bounds="279,488" />
-              <ControlPoint Id="DqKrF6chVDJOa2VfAFqMpO" Bounds="463,488" />
+              <ControlPoint Id="PDNcNVMPAmsNmaYagEnhEn" Bounds="145,141" />
+              <ControlPoint Id="TTSisu8Z8AkL5ZiRG6oXGQ" Bounds="123,112" />
+              <ControlPoint Id="RDZWSD37nxYQKq5iIi9Fq5" Bounds="168,161" />
+              <ControlPoint Id="LO4D5k5wr24N0s7ypFWJq5" Bounds="101,92" />
+              <ControlPoint Id="MaCEAzBuExXNaRKjzQ7CsL" Bounds="89,61" />
+              <ControlPoint Id="NayADq5zYezOXN0dX6GzFX" Bounds="89,364" />
+              <ControlPoint Id="DqKrF6chVDJOa2VfAFqMpO" Bounds="273,364" />
+              <ControlPoint Id="PXzBxrrak3pPKlZ7aFsiS3" Bounds="190,190" />
             </Canvas>
             <Patch Id="J376gtFi2T5MpkcezWda4x" Name="Create" />
-            <Patch Id="OLuCgZtSkrrOpE7XkdMd1V" Name="Update">
+            <Patch Id="OLuCgZtSkrrOpE7XkdMd1V" Name="Update" ManuallySortedPins="true">
               <Pin Id="RjwmWhhwZcoOnnLw4hILCR" Name="URL" Kind="InputPin" Bounds="313,222" />
               <Pin Id="EMdWT3vTBEXPIl26rXnsWr" Name="Headers" Kind="InputPin" Bounds="428,252" />
               <Pin Id="RwSMFwOiAydMwPFZ0go2Dw" Name="Body" Kind="InputPin" Bounds="484,272" />
               <Pin Id="E6krX4YuHDhLxwToSY8yRy" Name="Method" Kind="InputPin" Bounds="378,232" />
+              <Pin Id="NsZRNgTjPqJM7sUiJdhcsn" Name="Timeout" Kind="InputPin" />
               <Pin Id="Q2oQFphNhpNOvaC8hPM3QT" Name="Refresh" Kind="InputPin" Bounds="584,250" />
               <Pin Id="TrbHStDu8RbMtEzwD6tVaB" Name="Result" Kind="OutputPin" Bounds="279,488" />
               <Pin Id="B1pSsKDU7U6P734S8VsMO1" Name="In Progress" Kind="OutputPin" Bounds="462,488" />
@@ -744,6 +818,8 @@
             <Link Id="N8xQtzRmmD9NYlcxd5VuNF" Ids="NayADq5zYezOXN0dX6GzFX,TrbHStDu8RbMtEzwD6tVaB" IsHidden="true" />
             <Link Id="DnWz2mg60tmNfOQMBFKxVY" Ids="BEDMmKdZJ5NNS445NEcz1b,DqKrF6chVDJOa2VfAFqMpO" />
             <Link Id="H7pcRGg7QN7Ph0XDIIl8PC" Ids="DqKrF6chVDJOa2VfAFqMpO,B1pSsKDU7U6P734S8VsMO1" IsHidden="true" />
+            <Link Id="JSTAYtniq1DMz8XMBMvkY3" Ids="PXzBxrrak3pPKlZ7aFsiS3,Njl0tFuxFmJOK6rv7eoBKp" />
+            <Link Id="JOR9NytVIvkNuUpj07Sa0r" Ids="NsZRNgTjPqJM7sUiJdhcsn,PXzBxrrak3pPKlZ7aFsiS3" IsHidden="true" />
           </Patch>
         </Node>
         <!--
@@ -751,7 +827,7 @@
     ************************ ResponseData ************************
 
 -->
-        <Node Name="ResponseData" Bounds="341,356" Id="KE1sloGUyzfLGFYPdrRN7M">
+        <Node Name="ResponseData" Bounds="97,146" Id="KE1sloGUyzfLGFYPdrRN7M">
           <p:NodeReference>
             <Choice Kind="RecordDefinition" Name="Record" />
             <FullNameCategoryReference ID="Primitive" />
@@ -759,7 +835,7 @@
           <Patch Id="OMlmUtwSFmrPp1c7ySVMP6">
             <Canvas Id="EzrXxD273fELrOxi3PjxHk" CanvasType="Group">
               <Node Bounds="91,137,505,19" Id="JgjeYqtojF9N3EI3KZMb9i">
-                <p:NodeReference LastCategoryFullName="IO.HTTP" LastSymbolSource="VL.SimpleHTTP.vl">
+                <p:NodeReference LastCategoryFullName="IO.HTTP" LastDependency="VL.SimpleHTTP.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="RetrieveBasicResponseData" />
                 </p:NodeReference>
@@ -885,24 +961,26 @@
     ************************ Request (Blocking ResponseData) ************************
 
 -->
-        <Node Name="Request (Blocking ResponseData)" Bounds="339,444" Id="SAJxkqI1ZskNZwhWOtjM3v">
-          <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="Builtin">
+        <Node Name="Request (Blocking ResponseData)" Bounds="95,234" Id="SAJxkqI1ZskNZwhWOtjM3v">
+          <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
             <Choice Kind="ContainerDefinition" Name="Process" />
           </p:NodeReference>
           <Patch Id="EvfZqatpW0OOF5IrBns1XC">
             <Canvas Id="Pj6EXMNRVm7OhPYo91sTg7" CanvasType="Group">
-              <ControlPoint Id="RTI3mXZjRq5Ly3MOnOU1td" Bounds="460,476" />
-              <ControlPoint Id="Nvl0P6U5pjsP0J4lHo2ITW" Bounds="635,476" />
-              <ControlPoint Id="N3ZHqf2mzZeP2zsWUo4hMI" Bounds="517,477" />
-              <ControlPoint Id="BTcfmREHN2UOiyt9SM71Ki" Bounds="589,477" />
-              <Node Bounds="440,534,123,135" Id="TDDS0qqSzXgNJWyfyHtvY5">
-                <p:NodeReference LastCategoryFullName="Reactive" LastSymbolSource="VL.Reactive.vl">
+              <ControlPoint Id="RTI3mXZjRq5Ly3MOnOU1td" Bounds="102,151" />
+              <ControlPoint Id="Nvl0P6U5pjsP0J4lHo2ITW" Bounds="169,210" />
+              <ControlPoint Id="N3ZHqf2mzZeP2zsWUo4hMI" Bounds="124,171" />
+              <ControlPoint Id="BTcfmREHN2UOiyt9SM71Ki" Bounds="146,190" />
+              <Node Bounds="83,263,123,135" Id="TDDS0qqSzXgNJWyfyHtvY5">
+                <p:NodeReference LastCategoryFullName="Reactive" LastDependency="VL.Reactive.vl">
                   <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
                   <Choice Kind="ProcessAppFlag" Name="ForEach" />
                   <CategoryReference Kind="Category" Name="Reactive" NeedsToBeDirectParent="true" />
                 </p:NodeReference>
+                <Pin Id="RgUAhys7ZpNQbMR1NlIkC2" Name="Node Context" Kind="InputPin" IsHidden="true" />
                 <Pin Id="ARD5NB7Dg8BL0RR2TEczIs" Name="Messages" Kind="InputPin" />
                 <Pin Id="VjEgbVn3nHoPiKNf40P1r2" Name="Reset" Kind="InputPin" />
+                <Pin Id="Ie5OlLWaudhL6VGUgOrITn" Name="Output" Kind="OutputPin" IsHidden="true" />
                 <Pin Id="RkJgCNWwxHOP9tqkE0fm1j" Name="Result" Kind="OutputPin" />
                 <Patch Id="FnH2JoVcq1YPeeF152u62m" ManuallySortedPins="true">
                   <Patch Id="E6WIjlezHLfQOZXeVT83UY" Name="Create" ManuallySortedPins="true" />
@@ -910,10 +988,10 @@
                     <Pin Id="OJQnDXdmqrzL3LTqT4Fyjw" Name="Input 1" Kind="InputPin" />
                     <Pin Id="BzJ9UsPEqcBNEiOPPYGzpv" Name="Output" Kind="OutputPin" />
                   </Patch>
-                  <ControlPoint Id="KdQK0NckIqBOSNQO0eMfT3" Bounds="444,542" />
-                  <ControlPoint Id="OxWBESAddnCOk45dEBRZ0O" Bounds="459,662" />
-                  <Node Bounds="457,571,-101,19" Id="QoE2vNX4cANMogSKbS69Jz">
-                    <p:NodeReference LastCategoryFullName="IO.HTTP" LastSymbolSource="VL.SimpleHTTP.vl">
+                  <ControlPoint Id="KdQK0NckIqBOSNQO0eMfT3" Bounds="87,271" />
+                  <ControlPoint Id="OxWBESAddnCOk45dEBRZ0O" Bounds="102,391" />
+                  <Node Bounds="100,300,94,19" Id="QoE2vNX4cANMogSKbS69Jz">
+                    <p:NodeReference LastCategoryFullName="IO.HTTP" LastDependency="VL.SimpleHTTP.vl">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <Choice Kind="OperationCallFlag" Name="SimpleQueryBase" />
                     </p:NodeReference>
@@ -922,30 +1000,34 @@
                     <Pin Id="Mm8H9GtVQHoPudhRyQEn9L" Name="Body" Kind="InputPin" />
                     <Pin Id="IQ20ysZeRvIO5K12PSzNVb" Name="Method" Kind="InputPin" />
                     <Pin Id="UjnkBsT8DArOXd3v5SWjwd" Name="Result" Kind="OutputPin" />
+                    <Pin Id="QRK5a6B1jjdOALFfuyiHWW" Name="Timeout" Kind="InputPin" />
                   </Node>
-                  <Node Bounds="457,611,67,26" Id="U2hyylekxUPNMm87zrkwJq">
-                    <p:NodeReference LastCategoryFullName="IO.HTTP.ResponseData" LastSymbolSource="VL.SimpleHTTP.vl">
+                  <Node Bounds="100,340,67,26" Id="U2hyylekxUPNMm87zrkwJq">
+                    <p:NodeReference LastCategoryFullName="IO.HTTP.ResponseData" LastDependency="VL.SimpleHTTP.vl">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <CategoryReference Kind="RecordType" Name="ResponseData" />
                       <Choice Kind="OperationCallFlag" Name="Create" />
                     </p:NodeReference>
+                    <Pin Id="LWFcMFKDmkSNsKSMAQ9S0Y" Name="Node Context" Kind="InputPin" IsHidden="true" />
                     <Pin Id="BnfWOJDHxp8NnNB6YV9Qyg" Name="Response" Kind="InputPin" />
                     <Pin Id="LdU1XOtezZRNXjuPNIGKb2" Name="Output" Kind="StateOutputPin" />
                   </Node>
                 </Patch>
               </Node>
-              <Node Bounds="440,372,79,19" Id="PPwVKhXJf4vM2aHPyVVxkq">
-                <p:NodeReference LastCategoryFullName="Reactive" LastSymbolSource="VL.Reactive.vl">
+              <Node Bounds="83,101,79,19" Id="PPwVKhXJf4vM2aHPyVVxkq">
+                <p:NodeReference LastCategoryFullName="Reactive" LastDependency="VL.Reactive.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="ProcessAppFlag" Name="ToObservable" />
                 </p:NodeReference>
+                <Pin Id="NmJXqTnFn9AQVaqH6BlYxA" Name="Node Context" Kind="InputPin" IsHidden="true" />
                 <Pin Id="MYgtqAAqpcwMV5jK1fNLoo" Name="Message" Kind="InputPin" />
                 <Pin Id="EvsgD4iKE8cQCTMeZ53xdo" Name="Send" Kind="InputPin" />
+                <Pin Id="CFcScTy7uLBLE9OogrMhpW" Name="Output" Kind="OutputPin" IsHidden="true" />
                 <Pin Id="GDSwlYThsuJPK1AkHDKdEF" Name="Result" Kind="OutputPin" />
               </Node>
-              <ControlPoint Id="VYObeuFsTT3Ma1oMFu5IQL" Bounds="516,352" />
-              <Pad Id="C2HesEDfzLeLOYFaKOdnpw" Comment="" Bounds="442,355,35,15" ShowValueBox="true" isIOBox="true" Value="False">
-                <p:TypeAnnotation>
+              <ControlPoint Id="VYObeuFsTT3Ma1oMFu5IQL" Bounds="159,81" />
+              <Pad Id="C2HesEDfzLeLOYFaKOdnpw" Comment="" Bounds="85,84,35,15" ShowValueBox="true" isIOBox="true" Value="False">
+                <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="ImmutableTypeFlag" Name="Boolean" />
                   <FullNameCategoryReference ID="Primitive" />
                 </p:TypeAnnotation>
@@ -953,18 +1035,22 @@
                   <p:buttonmode p:Assembly="VL.UI.Forms" p:Type="VL.HDE.PatchEditor.Editors.ButtonModeEnum">Bang</p:buttonmode>
                 </p:ValueBoxSettings>
               </Pad>
-              <Node Bounds="440,717,65,19" Id="P3TIGBR3npILXkO5AwgcuZ">
-                <p:NodeReference LastCategoryFullName="Reactive" LastSymbolSource="VL.Reactive.vl">
+              <Node Bounds="83,446,65,19" Id="P3TIGBR3npILXkO5AwgcuZ">
+                <p:NodeReference LastCategoryFullName="Reactive" LastDependency="VL.Reactive.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="ProcessAppFlag" Name="HoldLatest" />
                 </p:NodeReference>
+                <Pin Id="TsWsu3lwQ0GP73QC5V5bGX" Name="Node Context" Kind="InputPin" IsHidden="true" />
+                <Pin Id="DWUrxaZgrjMLSz9R4EJyyL" Name="Initial Result" Kind="InputPin" IsHidden="true" />
                 <Pin Id="AbXjafW58ffMMHR7HaVGPI" Name="Async Notifications" Kind="InputPin" />
                 <Pin Id="M4Ome25FR9aPg7grk9Y2qJ" Name="Reset" Kind="InputPin" />
+                <Pin Id="FCJFCTB5ubjMx92AHhYBFs" Name="Output" Kind="OutputPin" IsHidden="true" />
                 <Pin Id="LdvkiA1rpVUOnhcXwnSVzK" Name="Value" Kind="OutputPin" />
                 <Pin Id="RqE5QCZ0lWxLrdNw4mY8oQ" Name="On Data" Kind="OutputPin" />
               </Node>
-              <ControlPoint Id="SDlDSpJoGADNPMFjS30mMr" Bounds="523,779" />
-              <ControlPoint Id="LOBZRQktjZRLNrSrmL4sGO" Bounds="442,779" />
+              <ControlPoint Id="SDlDSpJoGADNPMFjS30mMr" Bounds="145,490" />
+              <ControlPoint Id="LOBZRQktjZRLNrSrmL4sGO" Bounds="85,508" />
+              <ControlPoint Id="KZUP6O9aD90MWQSc2kbq6G" Bounds="191,239" />
             </Canvas>
             <ProcessDefinition Id="EguE19t9HbcNdO5MgH4VnW">
               <Fragment Id="VZQ0eJIrG8eOaOw51suKRo" Patch="L8qHedD1jomOgiXJ54GVzz" Enabled="true" />
@@ -993,16 +1079,16 @@
             <Patch Id="CBt8dfO2sMnMOxgmM5QfST" Name="Update" ManuallySortedPins="true">
               <Pin Id="NjQu3jtk4mjNqVKe3JllNE" Name="URL" Kind="InputPin" Bounds="498,323" />
               <Pin Id="HbCM1kiaFQ8NR9u3mPn2Zk" Name="Headers" Kind="InputPin" Bounds="551,333">
-                <p:TypeAnnotation LastCategoryFullName="Collections" LastSymbolSource="VL.Collections.vl">
+                <p:TypeAnnotation LastCategoryFullName="Collections" LastDependency="VL.Collections.vl">
                   <Choice Kind="TypeFlag" Name="Spread" />
                   <p:TypeArguments>
-                    <TypeReference LastCategoryFullName="Collections.Common" LastSymbolSource="VL.Collections.vl">
+                    <TypeReference LastCategoryFullName="Collections.Common" LastDependency="VL.Collections.vl">
                       <Choice Kind="TypeFlag" Name="KeyValuePair" />
                       <p:TypeArguments>
-                        <TypeReference LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+                        <TypeReference LastCategoryFullName="Primitive" LastDependency="CoreLibBasics.vl">
                           <Choice Kind="TypeFlag" Name="String" />
                         </TypeReference>
-                        <TypeReference LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+                        <TypeReference LastCategoryFullName="Primitive" LastDependency="CoreLibBasics.vl">
                           <Choice Kind="TypeFlag" Name="String" />
                         </TypeReference>
                       </p:TypeArguments>
@@ -1011,17 +1097,20 @@
                 </p:TypeAnnotation>
               </Pin>
               <Pin Id="R8I6K4zIPCZLUCGXdNxZvI" Name="Body" Kind="InputPin" Bounds="623,334">
-                <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+                <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="CoreLibBasics.vl">
                   <Choice Kind="TypeFlag" Name="String" />
                 </p:TypeAnnotation>
               </Pin>
               <Pin Id="C5TzuI4ZMBpP93QXfdNc4b" Name="Method" Kind="InputPin" Bounds="482,339" />
+              <Pin Id="NJWFV1K12JmNaOqDtSiZ6P" Name="Timeout" Kind="InputPin" />
               <Pin Id="IsIrixNznjTOVThUm1v4Qc" Name="Refresh" Kind="InputPin" Bounds="1104,297" />
               <Pin Id="FQckXc0PMZJNaBvBt5Og6j" Name="Response" Kind="OutputPin" Bounds="359,711" />
               <Pin Id="FYRiFQe4Mj8Pe7qe6LyWZC" Name="On Data" Kind="OutputPin" Bounds="1207,530" />
             </Patch>
             <Link Id="Txjhw6WK7EQQQiRWn7Rjrk" Ids="UjnkBsT8DArOXd3v5SWjwd,BnfWOJDHxp8NnNB6YV9Qyg" />
             <Link Id="LbrafngYKthQRY8bVBa4vf" Ids="LdU1XOtezZRNXjuPNIGKb2,OxWBESAddnCOk45dEBRZ0O" />
+            <Link Id="AbSN24RemSuLUnDKO6AxiS" Ids="KZUP6O9aD90MWQSc2kbq6G,QRK5a6B1jjdOALFfuyiHWW" />
+            <Link Id="JPilZkJDct8NV4CP3qCLT4" Ids="NJWFV1K12JmNaOqDtSiZ6P,KZUP6O9aD90MWQSc2kbq6G" IsHidden="true" />
           </Patch>
         </Node>
         <!--
@@ -1029,24 +1118,26 @@
     ************************ Request (Blocking Reactive) ************************
 
 -->
-        <Node Name="Request (Blocking Reactive)" Bounds="618,309" Id="AIbqyZ1rY8BMxgjeWSyacT">
-          <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="Builtin">
+        <Node Name="Request (Blocking Reactive)" Bounds="390,109" Id="AIbqyZ1rY8BMxgjeWSyacT">
+          <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
             <Choice Kind="ContainerDefinition" Name="Process" />
           </p:NodeReference>
           <Patch Id="TFsauJvp9yvMehjz75BIll">
             <Canvas Id="SZPolLhD3jXNhdcTDi1LKb" CanvasType="Group">
-              <ControlPoint Id="Jn5DWL8SK7DOxb20OXstiS" Bounds="460,476" />
-              <ControlPoint Id="DW1VG6HKtXkLYGzL3Nj91E" Bounds="635,476" />
-              <ControlPoint Id="FOY3DaPdfTkMNCXSiXuWfT" Bounds="517,477" />
-              <ControlPoint Id="RHMMT09VQ8ePkMm4YMpdOJ" Bounds="589,477" />
-              <Node Bounds="440,534,123,135" Id="Jdot2KNRZgYM3jgYiTJeLw">
-                <p:NodeReference LastCategoryFullName="Reactive" LastSymbolSource="VL.Reactive.vl">
+              <ControlPoint Id="Jn5DWL8SK7DOxb20OXstiS" Bounds="156,181" />
+              <ControlPoint Id="DW1VG6HKtXkLYGzL3Nj91E" Bounds="223,251" />
+              <ControlPoint Id="FOY3DaPdfTkMNCXSiXuWfT" Bounds="178,202" />
+              <ControlPoint Id="RHMMT09VQ8ePkMm4YMpdOJ" Bounds="200,231" />
+              <Node Bounds="137,294,123,135" Id="Jdot2KNRZgYM3jgYiTJeLw">
+                <p:NodeReference LastCategoryFullName="Reactive" LastDependency="VL.Reactive.vl">
                   <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
                   <Choice Kind="ProcessAppFlag" Name="ForEach" />
                   <CategoryReference Kind="Category" Name="Reactive" NeedsToBeDirectParent="true" />
                 </p:NodeReference>
+                <Pin Id="VcPkPIPsjB0QI69I5mrbHE" Name="Node Context" Kind="InputPin" IsHidden="true" />
                 <Pin Id="DSrrWDCKvhdPWbFWHOj7p4" Name="Messages" Kind="InputPin" />
                 <Pin Id="VzDIwxhBSZLQSbHcMUXVi7" Name="Reset" Kind="InputPin" />
+                <Pin Id="HIp4vyGSzuBPx4l9sjowSx" Name="Output" Kind="OutputPin" IsHidden="true" />
                 <Pin Id="Dn1ZlaqfoB7MWjwHzLkKnd" Name="Result" Kind="OutputPin" />
                 <Patch Id="SULqnjmL8QWPM11hRfnARg" ManuallySortedPins="true">
                   <Patch Id="R3adUrGkCxDOBv1LjO5buJ" Name="Create" ManuallySortedPins="true" />
@@ -1054,10 +1145,10 @@
                     <Pin Id="RcOmVcVam7rPW5IZvWjjIE" Name="Input 1" Kind="InputPin" />
                     <Pin Id="PHP0wJ08viUP0EsoGkQ6Yi" Name="Output" Kind="OutputPin" />
                   </Patch>
-                  <ControlPoint Id="JDmFWtZUmSDQJHFZAKGSGE" Bounds="444,542" />
-                  <ControlPoint Id="AKrMnKrH2asPiImZsjk80m" Bounds="459,662" />
-                  <Node Bounds="457,571,-101,19" Id="GfZ6kPJzKhGMKUrFctXYdC">
-                    <p:NodeReference LastCategoryFullName="IO.HTTP" LastSymbolSource="VL.SimpleHTTP.vl">
+                  <ControlPoint Id="JDmFWtZUmSDQJHFZAKGSGE" Bounds="141,302" />
+                  <ControlPoint Id="AKrMnKrH2asPiImZsjk80m" Bounds="156,422" />
+                  <Node Bounds="154,331,94,19" Id="GfZ6kPJzKhGMKUrFctXYdC">
+                    <p:NodeReference LastCategoryFullName="IO.HTTP" LastDependency="VL.SimpleHTTP.vl">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <Choice Kind="OperationCallFlag" Name="SimpleQueryBase" />
                     </p:NodeReference>
@@ -1066,30 +1157,34 @@
                     <Pin Id="HP9VzaFinJ9NaH3G60cEJL" Name="Body" Kind="InputPin" />
                     <Pin Id="Uy7Pi9I6SQPPrGnZbSlK8y" Name="Method" Kind="InputPin" />
                     <Pin Id="PabmbeAYjOfLInMV8XPGH9" Name="Result" Kind="OutputPin" />
+                    <Pin Id="PoUwQiUbMQONFHwijBXfmM" Name="Timeout" Kind="InputPin" />
                   </Node>
-                  <Node Bounds="457,612,67,26" Id="CdMSVcwkV7POTZVCjjKEw5">
-                    <p:NodeReference LastCategoryFullName="IO.HTTP.ResponseData" LastSymbolSource="VL.SimpleHTTP.vl">
+                  <Node Bounds="154,372,67,26" Id="CdMSVcwkV7POTZVCjjKEw5">
+                    <p:NodeReference LastCategoryFullName="IO.HTTP.ResponseData" LastDependency="VL.SimpleHTTP.vl">
                       <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                       <CategoryReference Kind="RecordType" Name="ResponseData" />
                       <Choice Kind="OperationCallFlag" Name="Create" />
                     </p:NodeReference>
+                    <Pin Id="S64gsxUSiqHNj4tbV0ArPN" Name="Node Context" Kind="InputPin" IsHidden="true" />
                     <Pin Id="MgGPxGyEbklQGaKIzLUpF2" Name="Response" Kind="InputPin" />
                     <Pin Id="M5bi7FeIORyPPmul83FVWR" Name="Output" Kind="StateOutputPin" />
                   </Node>
                 </Patch>
               </Node>
-              <Node Bounds="440,372,79,19" Id="RVDbSd5QsNCM9SVDcBsdNk">
-                <p:NodeReference LastCategoryFullName="Reactive" LastSymbolSource="VL.Reactive.vl">
+              <Node Bounds="137,132,79,19" Id="RVDbSd5QsNCM9SVDcBsdNk">
+                <p:NodeReference LastCategoryFullName="Reactive" LastDependency="VL.Reactive.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="ProcessAppFlag" Name="ToObservable" />
                 </p:NodeReference>
+                <Pin Id="UG8h8wtvZIZQR3IY1wj5Ws" Name="Node Context" Kind="InputPin" IsHidden="true" />
                 <Pin Id="JvOCPNz1KGBO4AJ0YdGq9r" Name="Message" Kind="InputPin" />
                 <Pin Id="E69YGnBSb0kQPmUDBggGro" Name="Send" Kind="InputPin" />
+                <Pin Id="R10e361OOTXQFMP9LFYmJT" Name="Output" Kind="OutputPin" IsHidden="true" />
                 <Pin Id="KHNo4qUoqYTP1u6LrbYCFm" Name="Result" Kind="OutputPin" />
               </Node>
-              <ControlPoint Id="DCp4YeNaWbmPYacA5Vl4T2" Bounds="516,352" />
-              <Pad Id="U0ZV8DGVTyLNW2v9ZAqLEC" Comment="" Bounds="442,355,35,15" ShowValueBox="true" isIOBox="true" Value="False">
-                <p:TypeAnnotation>
+              <ControlPoint Id="DCp4YeNaWbmPYacA5Vl4T2" Bounds="213,112" />
+              <Pad Id="U0ZV8DGVTyLNW2v9ZAqLEC" Comment="" Bounds="139,115,35,15" ShowValueBox="true" isIOBox="true" Value="False">
+                <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
                   <Choice Kind="ImmutableTypeFlag" Name="Boolean" />
                   <FullNameCategoryReference ID="Primitive" />
                 </p:TypeAnnotation>
@@ -1097,7 +1192,8 @@
                   <p:buttonmode p:Assembly="VL.UI.Forms" p:Type="VL.HDE.PatchEditor.Editors.ButtonModeEnum">Bang</p:buttonmode>
                 </p:ValueBoxSettings>
               </Pad>
-              <ControlPoint Id="KRxmfvKQibxOBkrcdG36xF" Bounds="442,707" />
+              <ControlPoint Id="KRxmfvKQibxOBkrcdG36xF" Bounds="139,467" />
+              <ControlPoint Id="DfCWbWZU1nQMPaNal9V9Sv" Bounds="245,271" />
             </Canvas>
             <ProcessDefinition Id="A9XGZEYlgTdMEI7pn9bh3o">
               <Fragment Id="VwivmkOEs29MwDjy9b1xf7" Patch="U4cj0yNGDmuPFJQmUaf8lb" Enabled="true" />
@@ -1123,16 +1219,16 @@
             <Patch Id="P0vLGHsffP9PlniyNEIcbo" Name="Update" ManuallySortedPins="true">
               <Pin Id="Fw2pyGNN3kRMrKYw8a2xrx" Name="URL" Kind="InputPin" Bounds="498,323" />
               <Pin Id="AskwQqi31V9PzgszxB1i08" Name="Headers" Kind="InputPin" Bounds="551,333">
-                <p:TypeAnnotation LastCategoryFullName="Collections" LastSymbolSource="VL.Collections.vl">
+                <p:TypeAnnotation LastCategoryFullName="Collections" LastDependency="VL.Collections.vl">
                   <Choice Kind="TypeFlag" Name="Spread" />
                   <p:TypeArguments>
-                    <TypeReference LastCategoryFullName="Collections.Common" LastSymbolSource="VL.Collections.vl">
+                    <TypeReference LastCategoryFullName="Collections.Common" LastDependency="VL.Collections.vl">
                       <Choice Kind="TypeFlag" Name="KeyValuePair" />
                       <p:TypeArguments>
-                        <TypeReference LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+                        <TypeReference LastCategoryFullName="Primitive" LastDependency="CoreLibBasics.vl">
                           <Choice Kind="TypeFlag" Name="String" />
                         </TypeReference>
-                        <TypeReference LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+                        <TypeReference LastCategoryFullName="Primitive" LastDependency="CoreLibBasics.vl">
                           <Choice Kind="TypeFlag" Name="String" />
                         </TypeReference>
                       </p:TypeArguments>
@@ -1141,16 +1237,19 @@
                 </p:TypeAnnotation>
               </Pin>
               <Pin Id="IkTL7MS2ljJNdP5fj6bnG1" Name="Body" Kind="InputPin" Bounds="623,334">
-                <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+                <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="CoreLibBasics.vl">
                   <Choice Kind="TypeFlag" Name="String" />
                 </p:TypeAnnotation>
               </Pin>
               <Pin Id="L5HMPxuBHblLmL4uUyaafb" Name="Method" Kind="InputPin" Bounds="482,339" />
               <Pin Id="P0ZdiAhTuIqL9WAad8aED3" Name="Refresh" Kind="InputPin" Bounds="1104,297" />
               <Pin Id="AW84GtL3kUNNrwXEeCWhrP" Name="Result" Kind="OutputPin" Bounds="364,722" />
+              <Pin Id="LZzNqNvw1sBOUiqmAszEp6" Name="Timeout" Kind="InputPin" />
             </Patch>
             <Link Id="R6s0pqZ0Kl6LUD6veNULJw" Ids="PabmbeAYjOfLInMV8XPGH9,MgGPxGyEbklQGaKIzLUpF2" />
             <Link Id="TLfIgUPW1PMQAFPkQOVN3v" Ids="M5bi7FeIORyPPmul83FVWR,AKrMnKrH2asPiImZsjk80m" />
+            <Link Id="NHXvYMSQRFyN3a68asZMC0" Ids="DfCWbWZU1nQMPaNal9V9Sv,PoUwQiUbMQONFHwijBXfmM" />
+            <Link Id="I0Y8XCH2mvINWOnNscJDJu" Ids="LZzNqNvw1sBOUiqmAszEp6,DfCWbWZU1nQMPaNal9V9Sv" IsHidden="true" />
           </Patch>
         </Node>
       </Canvas>
@@ -1176,7 +1275,7 @@
       </Patch>
     </Node>
   </Patch>
-  <NugetDependency Id="K7oHRdICwk5M2afHeGagru" Location="VL.CoreLib" Version="2021.4.11-1332-g34bbc10a05" />
+  <NugetDependency Id="K7oHRdICwk5M2afHeGagru" Location="VL.CoreLib" Version="2025.7.1-0042-gb4eb70cb8e" />
   <PlatformDependency Id="QX7iOYDTI12OVfr49PJtpY" Location="System" />
-  <NugetDependency Id="HDjxOXI3EmcMM1pqV05JIs" Location="RestSharp" Version="106.15.0" />
+  <NugetDependency Id="HDjxOXI3EmcMM1pqV05JIs" Location="RestSharp" Version="112.1.0" />
 </Document>

--- a/deployment/VL.SimpleHTTP.nuspec
+++ b/deployment/VL.SimpleHTTP.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd">
   <metadata>
     <id>VL.SimpleHTTP</id>
-    <version>1.2.1</version>
+    <version>1.3.0</version>
     <authors>sebescudie</authors>
     <owners>sebescudie</owners>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
@@ -11,9 +11,9 @@
     <description>Simple HTTP nodes for the VL programming language </description>
     <summary>Simple HTTP nodes for the VL programming language </summary>
     <language>en-US</language>
-    <tags>vl http query</tags>
+    <tags>vl vvvv http query</tags>
     <dependencies>
-      <dependency id="RestSharp" version="[106.15.0]" />
+      <dependency id="RestSharp" version="[112.1.0]" />
     </dependencies>
   </metadata>
   <files>

--- a/help/Explanation Blocking vs async Request nodes.vl
+++ b/help/Explanation Blocking vs async Request nodes.vl
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Document xmlns:p="property" Id="Nc5RC6QjbyTN6Lm185hyCJ" LanguageVersion="2021.4.6.835" Version="0.128">
+<Document xmlns:p="property" xmlns:r="reflection" Id="Nc5RC6QjbyTN6Lm185hyCJ" LanguageVersion="2025.7.1-0042-gb4eb70cb8e" Version="0.128">
   <Patch Id="Lc7kpo3UJEVPCKyKlqJwP7">
     <Canvas Id="RAXIwoBDv38OOYriL91QVu" DefaultCategory="Main" BordersChecked="false" CanvasType="FullCategory" />
     <!--
@@ -15,40 +15,46 @@
       <Patch Id="Iv9Km99ndieOOkguJy05DO">
         <Canvas Id="BLcDs6NZJLqMIsfNkBExet" CanvasType="Group">
           <Node Bounds="559,374,105,19" Id="EQGtuGu2QbVNtsRTKT2mlq">
-            <p:NodeReference>
+            <p:NodeReference LastCategoryFullName="IO.HTTP" LastDependency="VL.SimpleHTTP.vl">
               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
               <Choice Kind="ProcessAppFlag" Name="Request (Async)" />
             </p:NodeReference>
+            <Pin Id="PtPlPZUBQTRMqy9pjXNdba" Name="Node Context" Kind="InputPin" IsHidden="true" />
             <Pin Id="IGuIJoqbZHqOmtroNqL3Jt" Name="URL" Kind="InputPin" />
             <Pin Id="O6kuAtXkLJ6OpNlR8K2vfY" Name="Headers" Kind="InputPin" />
             <Pin Id="TCcMU3HMxV6LMHyzVZJfL9" Name="Body" Kind="InputPin" />
             <Pin Id="Hr6LJIKpeXkPiJbxRJTmhB" Name="Method" Kind="InputPin" />
+            <Pin Id="R2sOB7hCUQ9OHbmcLNxV0Q" Name="Timeout" Kind="InputPin" />
             <Pin Id="EgE0tGDwB6DPNsUOIHCs8k" Name="Refresh" Kind="InputPin" />
             <Pin Id="RWm5bCB5fe8P1usTedEY16" Name="Content" Kind="OutputPin" />
+            <Pin Id="OF8evN0DB5nNrECV0rchlV" Name="Raw Bytes" Kind="OutputPin" IsHidden="true" />
             <Pin Id="BqeK3C1dhL3MBkKVGl9ru7" Name="Status Code" Kind="OutputPin" />
             <Pin Id="VPMmsYvrVu9PWJ9xCdIohM" Name="Status Description" Kind="OutputPin" />
             <Pin Id="PsR84xxf3ByL3lJ4xqiBfQ" Name="Is Successful" Kind="OutputPin" />
             <Pin Id="DRUkUgQS1UqOItcYsdEvJf" Name="On Data" Kind="OutputPin" />
             <Pin Id="TD3oJ7GoCVmMmVgA9Zyg08" Name="In Progress" Kind="OutputPin" />
           </Node>
-          <Node Bounds="259,374,85,19" Id="OARyuZ0oB9eNa3m6kd7CIL">
-            <p:NodeReference LastCategoryFullName="IO.HTTP" LastSymbolSource="VL.SimpleHTTP.vl">
+          <Node Bounds="259,370,105,19" Id="OARyuZ0oB9eNa3m6kd7CIL">
+            <p:NodeReference LastCategoryFullName="IO.HTTP" LastDependency="VL.SimpleHTTP.vl">
               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
               <Choice Kind="ProcessAppFlag" Name="Request (Blocking)" />
             </p:NodeReference>
+            <Pin Id="OBZgFUwZPEiPjihh3QDALh" Name="Node Context" Kind="InputPin" IsHidden="true" />
             <Pin Id="RoWnJMxErKEPtvWg8J2ulp" Name="URL" Kind="InputPin" />
             <Pin Id="CcycAZ1x4TrNJDzQLiwr9x" Name="Headers" Kind="InputPin" />
             <Pin Id="BNOKrP80jf2M5v3jBpogzu" Name="Body" Kind="InputPin" />
             <Pin Id="Iryq4ZSf8NoMcvebHvhJh1" Name="Method" Kind="InputPin" />
+            <Pin Id="JCk4DRHUSbKQM8A1D93t7u" Name="Timeout" Kind="InputPin" />
             <Pin Id="C5npkmnmH2WQPpORZIf941" Name="Refresh" Kind="InputPin" />
             <Pin Id="Joh3YX4MHagNZh0txxWaah" Name="Content" Kind="OutputPin" />
             <Pin Id="KJL0nP5elAzQIxUpMUjqnA" Name="Status Code" Kind="OutputPin" />
             <Pin Id="OGd50Wnp4a5N8EI9Ak9VWM" Name="Status Description" Kind="OutputPin" />
             <Pin Id="LFqswxbGI9IOwLUjBQvpau" Name="Is Successful" Kind="OutputPin" />
             <Pin Id="QihsgHMBN63Nmay5Iwd5J2" Name="On Data" Kind="OutputPin" />
+            <Pin Id="DoweOLB6qRpMj37ZjBJVfn" Name="Raw Bytes" Kind="OutputPin" IsHidden="true" />
           </Node>
           <Pad Id="GIZ03xB0OUuNK4kv3TvIXn" Bounds="59,89,438,31" ShowValueBox="true" isIOBox="true" Value="Blocking vs async Request nodes">
-            <p:TypeAnnotation>
+            <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
               <Choice Kind="TypeFlag" Name="String" />
             </p:TypeAnnotation>
             <p:ValueBoxSettings>
@@ -57,7 +63,7 @@
             </p:ValueBoxSettings>
           </Pad>
           <Pad Id="S8Tb9pAsAxxMwEvFQNOGgH" Bounds="59,156,752,78" ShowValueBox="true" isIOBox="true" Value="The Request node allows you to make basic HTTP requests and comes in two flavors : blocking and async. The blocking version will block the mainloop (your patch will freeze) while it's waiting for the result of the request. the async one won't.&#xD;&#xA;&#xD;&#xA;Let's visualize that with an LFO node and a request that purposedly takes a while to complete.">
-            <p:TypeAnnotation>
+            <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
               <Choice Kind="TypeFlag" Name="String" />
             </p:TypeAnnotation>
             <p:ValueBoxSettings>
@@ -65,13 +71,13 @@
               <p:stringtype p:Assembly="VL.Core" p:Type="VL.Core.StringType">Comment</p:stringtype>
             </p:ValueBoxSettings>
           </Pad>
-          <Pad Id="Kusiqi5KwlOOWhChlhNkM3" Comment="URL" Bounds="261,281,244,15" ShowValueBox="true" isIOBox="true" Value="https://hub.dummyapis.com/delay?seconds=2">
-            <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+          <Pad Id="Kusiqi5KwlOOWhChlhNkM3" Comment="URL" Bounds="261,261,244,15" ShowValueBox="true" isIOBox="true" Value="https://dummyjson.com/RESOURCE/?delay=3000">
+            <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="CoreLibBasics.vl">
               <Choice Kind="TypeFlag" Name="String" />
             </p:TypeAnnotation>
           </Pad>
-          <Pad Id="PWyFcHGNSacMaA9VBtOg6i" Comment="Refresh" Bounds="341,354,35,15" ShowValueBox="true" isIOBox="true" Value="False">
-            <p:TypeAnnotation>
+          <Pad Id="PWyFcHGNSacMaA9VBtOg6i" Comment="Refresh" Bounds="361,360,35,15" ShowValueBox="true" isIOBox="true" Value="False">
+            <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
               <Choice Kind="ImmutableTypeFlag" Name="Boolean" />
               <FullNameCategoryReference ID="Primitive" />
             </p:TypeAnnotation>
@@ -80,10 +86,13 @@
             </p:ValueBoxSettings>
           </Pad>
           <Node Bounds="101,327,45,19" Id="NvXuope7O6hQVRRNKBJ7va">
-            <p:NodeReference LastCategoryFullName="Animation" LastSymbolSource="CoreLibBasics.vl">
+            <p:NodeReference LastCategoryFullName="Animation" LastDependency="CoreLibBasics.vl">
               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
               <Choice Kind="ProcessAppFlag" Name="LFO" />
             </p:NodeReference>
+            <Pin Id="CuzhTfsNeZONI1oolvNzjc" Name="Node Context" Kind="InputPin" IsHidden="true" />
+            <Pin Id="CAEqsUef1QoNEjcTq8QYIz" Name="Clock" Kind="InputPin" IsHidden="true" />
+            <Pin Id="SJPHZYFh1m1NFSBZTQJ69l" Name="New Clock" Kind="InputPin" IsHidden="true" />
             <Pin Id="NelkkOEqvedNaWwcwvo8kp" Name="Period" Kind="InputPin" />
             <Pin Id="A2Svov0shJZQbiplpwmhja" Name="Pause" Kind="InputPin" />
             <Pin Id="BxXHYNzsv5IPWAmolcRFDl" Name="Reset" Kind="ApplyPin" />
@@ -97,7 +106,7 @@
             </p:ValueBoxSettings>
           </Pad>
           <Pad Id="Jmwf02EXfvhLa7izYNmUUn" Comment="Refresh" Bounds="661,354,35,15" ShowValueBox="true" isIOBox="true" Value="False">
-            <p:TypeAnnotation>
+            <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
               <Choice Kind="ImmutableTypeFlag" Name="Boolean" />
               <FullNameCategoryReference ID="Primitive" />
             </p:TypeAnnotation>
@@ -106,7 +115,7 @@
             </p:ValueBoxSettings>
           </Pad>
           <Pad Id="PqIcyVUiJllO1XQxcb8j9x" Bounds="212,278,29,27" ShowValueBox="true" isIOBox="true" Value="1.">
-            <p:TypeAnnotation>
+            <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
               <Choice Kind="TypeFlag" Name="String" />
             </p:TypeAnnotation>
             <p:ValueBoxSettings>
@@ -115,7 +124,7 @@
             </p:ValueBoxSettings>
           </Pad>
           <Pad Id="RFaEsGjwMM9Lm9523pxDqa" Bounds="212,374,29,27" ShowValueBox="true" isIOBox="true" Value="2.">
-            <p:TypeAnnotation>
+            <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
               <Choice Kind="TypeFlag" Name="String" />
             </p:TypeAnnotation>
             <p:ValueBoxSettings>
@@ -124,7 +133,7 @@
             </p:ValueBoxSettings>
           </Pad>
           <Pad Id="Bgv8YaAC5DBM6jfAt6Kw17" Bounds="515,374,29,27" ShowValueBox="true" isIOBox="true" Value="3.">
-            <p:TypeAnnotation>
+            <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
               <Choice Kind="TypeFlag" Name="String" />
             </p:TypeAnnotation>
             <p:ValueBoxSettings>
@@ -133,7 +142,7 @@
             </p:ValueBoxSettings>
           </Pad>
           <Pad Id="QiMgA8MVDwKMuPa7VjZ5rs" Bounds="75,579,29,27" ShowValueBox="true" isIOBox="true" Value="1.">
-            <p:TypeAnnotation>
+            <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
               <Choice Kind="TypeFlag" Name="String" />
             </p:TypeAnnotation>
             <p:ValueBoxSettings>
@@ -142,7 +151,7 @@
             </p:ValueBoxSettings>
           </Pad>
           <Pad Id="QNf3tiCxScfLx5ntq9OeSg" Bounds="116,580,660,39" ShowValueBox="true" isIOBox="true" Value="This endpoint does nothing special, it just delays its response by the number of seconds we give it as a parameter. Can be pretty handy for debug scenarios!">
-            <p:TypeAnnotation>
+            <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
               <Choice Kind="TypeFlag" Name="String" />
             </p:TypeAnnotation>
             <p:ValueBoxSettings>
@@ -150,7 +159,7 @@
               <p:stringtype p:Assembly="VL.Core" p:Type="VL.Core.StringType">Comment</p:stringtype>
             </p:ValueBoxSettings>
           </Pad>
-          <Pad Id="JI4hERVpE44P2683RnWSBI" Comment="On Data" Bounds="341,409,35,15" ShowValueBox="true" isIOBox="true" Value="False">
+          <Pad Id="JI4hERVpE44P2683RnWSBI" Comment="On Data" Bounds="361,410,35,15" ShowValueBox="true" isIOBox="true" Value="False">
             <p:ValueBoxSettings>
               <p:buttonmode p:Assembly="VL.UI.Forms" p:Type="VL.HDE.PatchEditor.Editors.ButtonModeEnum">Bang</p:buttonmode>
             </p:ValueBoxSettings>
@@ -166,7 +175,7 @@
             </p:ValueBoxSettings>
           </Pad>
           <Pad Id="TLAegRXbjVxPG1GpmwtKVs" Bounds="75,638,29,27" ShowValueBox="true" isIOBox="true" Value="2.">
-            <p:TypeAnnotation>
+            <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
               <Choice Kind="TypeFlag" Name="String" />
             </p:TypeAnnotation>
             <p:ValueBoxSettings>
@@ -174,8 +183,8 @@
               <p:stringtype p:Assembly="VL.Core" p:Type="VL.Core.StringType">Comment</p:stringtype>
             </p:ValueBoxSettings>
           </Pad>
-          <Pad Id="Pev1Jdz01TsPiWUXehgqZT" Bounds="116,639,660,39" ShowValueBox="true" isIOBox="true" Value="Have a look at the LFO on the left and bang the Refresh pin of this node : you'll see the LFO pauses while we are waiting for the answer.">
-            <p:TypeAnnotation>
+          <Pad Id="Pev1Jdz01TsPiWUXehgqZT" Bounds="116,639,694,40" ShowValueBox="true" isIOBox="true" Value="Have a look at the LFO on the left and bang the Refresh pin of this node : you'll see the LFO pauses while we are waiting for the answer. You can prevent a request &quot;from getting stuck&quot; for too long by defining a timeout.">
+            <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
               <Choice Kind="TypeFlag" Name="String" />
             </p:TypeAnnotation>
             <p:ValueBoxSettings>
@@ -186,7 +195,7 @@
           <Pad Id="UXVtba0yG71NP4pPLsLsxh" Comment="Content" Bounds="261,458,100,44" ShowValueBox="true" isIOBox="true" />
           <Pad Id="FImDxvARApBO3NEoDc3dgQ" Comment="Content" Bounds="561,458,100,44" ShowValueBox="true" isIOBox="true" />
           <Pad Id="JhVzActhCB6LxiKkou4Juy" Bounds="77,699,29,27" ShowValueBox="true" isIOBox="true" Value="3.">
-            <p:TypeAnnotation>
+            <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
               <Choice Kind="TypeFlag" Name="String" />
             </p:TypeAnnotation>
             <p:ValueBoxSettings>
@@ -194,8 +203,8 @@
               <p:stringtype p:Assembly="VL.Core" p:Type="VL.Core.StringType">Comment</p:stringtype>
             </p:ValueBoxSettings>
           </Pad>
-          <Pad Id="CUWkLMnqvAtOAilIT0cyY8" Bounds="116,700,660,39" ShowValueBox="true" isIOBox="true" Value="Now try the async version : you'll see the LFO does not freeze, and you get a toggle telling you the query is in progress. After two seconds, you get the result normally, but the mainloop was not stopped!">
-            <p:TypeAnnotation>
+          <Pad Id="CUWkLMnqvAtOAilIT0cyY8" Bounds="116,700,660,39" ShowValueBox="true" isIOBox="true" Value="Now try the async version : you'll see the LFO does not freeze, and you get a toggle telling you the query is in progress. After three seconds, you get the result normally, but the mainloop was not stopped!">
+            <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
               <Choice Kind="TypeFlag" Name="String" />
             </p:TypeAnnotation>
             <p:ValueBoxSettings>
@@ -203,6 +212,21 @@
               <p:stringtype p:Assembly="VL.Core" p:Type="VL.Core.StringType">Comment</p:stringtype>
             </p:ValueBoxSettings>
           </Pad>
+          <Node Bounds="339,310,95,19" Id="DnRyElvzlxjNBZrja2tYEP">
+            <p:NodeReference LastCategoryFullName="System.TimeSpan" LastDependency="VL.CoreLib.vl">
+              <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
+              <CategoryReference Kind="RecordType" Name="TimeSpan" />
+              <Choice Kind="OperationCallFlag" Name="FromMilliseconds" />
+            </p:NodeReference>
+            <Pin Id="HJ3PIFVWwQgLIXoRAOHcue" Name="Value" Kind="InputPin" />
+            <Pin Id="QDIMhXAVZhsMJAXBnAQyJb" Name="Result" Kind="OutputPin" />
+          </Node>
+          <Pad Id="MgTe92XjVIrMq7ubVRGADp" Comment="" Bounds="341,290,59,16" ShowValueBox="true" isIOBox="true" Value="1000">
+            <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
+              <Choice Kind="TypeFlag" Name="Float64" />
+            </p:TypeAnnotation>
+          </Pad>
+          <Pad Id="DGzqr4hNE5ELJ6mHYIxD3q" SlotId="IfYPkD3MeO8NvHx8mT3ETU" Bounds="341,350" Value="0" />
         </Canvas>
         <Patch Id="QCXMBhqgr9XL2tlT35fVm1" Name="Create" />
         <Patch Id="CeDaoMwBA0xN3OovzYX7Qu" Name="Update" />
@@ -220,9 +244,12 @@
         <Link Id="GCBXgzo88XJOM7ExOqjy1m" Ids="DRUkUgQS1UqOItcYsdEvJf,BXz46sOIEjbOBOSt42OPNy" />
         <Link Id="E0WWanukH9ILbDXEGUszO1" Ids="Joh3YX4MHagNZh0txxWaah,UXVtba0yG71NP4pPLsLsxh" />
         <Link Id="UngVFNOG7bGNfpG0ktZlJs" Ids="RWm5bCB5fe8P1usTedEY16,FImDxvARApBO3NEoDc3dgQ" />
+        <Link Id="SotQUeZSrR5ODACamX6Gdj" Ids="MgTe92XjVIrMq7ubVRGADp,HJ3PIFVWwQgLIXoRAOHcue" />
+        <Slot Id="IfYPkD3MeO8NvHx8mT3ETU" Name="Timeout" />
+        <Link Id="KxvICviDD4FM4jSgS3HJrw" Ids="QDIMhXAVZhsMJAXBnAQyJb,DGzqr4hNE5ELJ6mHYIxD3q" />
       </Patch>
     </Node>
   </Patch>
-  <NugetDependency Id="S5OVynr6jj9Mls1SJbrhwe" Location="VL.CoreLib" Version="2021.4.6" />
+  <NugetDependency Id="S5OVynr6jj9Mls1SJbrhwe" Location="VL.CoreLib" Version="2025.7.1-0042-gb4eb70cb8e" />
   <NugetDependency Id="FUxMQdTJ8IZQdmX8aXt9vz" Location="VL.SimpleHTTP" Version="0.0.0.0" />
 </Document>

--- a/help/HowTo Request an image.vl
+++ b/help/HowTo Request an image.vl
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Document xmlns:p="property" Id="ErbPL6pSPphNM77c7cVRaV" LanguageVersion="2021.4.6.835" Version="0.128">
+<Document xmlns:p="property" xmlns:r="reflection" Id="ErbPL6pSPphNM77c7cVRaV" LanguageVersion="2025.7.1-0042-gb4eb70cb8e" Version="0.128">
   <Patch Id="DQApQUF8ADhQWmitYJpHgc">
     <Canvas Id="Vds5fGSYB3WMgoKwL3Briz" DefaultCategory="Main" BordersChecked="false" CanvasType="FullCategory" />
     <!--
@@ -15,14 +15,16 @@
       <Patch Id="TzqudBqOWbWPZAPq7V1Ejl">
         <Canvas Id="GNLtwjwYrVgNJKcwLfRw0N" CanvasType="Group">
           <Node Bounds="125,241,125,19" Id="HKHP7Cmsye9MbnwFSQkLJV">
-            <p:NodeReference LastCategoryFullName="IO.HTTP" LastSymbolSource="VL.SimpleHTTP.vl">
+            <p:NodeReference LastCategoryFullName="IO.HTTP" LastDependency="VL.SimpleHTTP.vl">
               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
               <Choice Kind="ProcessAppFlag" Name="Request (Async)" />
             </p:NodeReference>
+            <Pin Id="Jyl0Dom0HCqMnTRfI8pdbA" Name="Node Context" Kind="InputPin" IsHidden="true" />
             <Pin Id="AM2j8n14OUPP6R4oaUWnTF" Name="URL" Kind="InputPin" />
             <Pin Id="PeG8Xpl0FDiLLWXTcMfC78" Name="Headers" Kind="InputPin" />
             <Pin Id="T64zymPmfsiMn1QUbDX2DN" Name="Body" Kind="InputPin" />
             <Pin Id="NVftgadepKZLZMc7NQPm3g" Name="Method" Kind="InputPin" />
+            <Pin Id="DettsysQtlaPdhwqPPaB6M" Name="Timeout" Kind="InputPin" />
             <Pin Id="H93v3QA47HmL3HfxhaXFNc" Name="Refresh" Kind="InputPin" />
             <Pin Id="TrQoOgZRKCVOMhe1JbCdFD" Name="Content" Kind="OutputPin" />
             <Pin Id="HUpadZaBocjLn4wji0BcqM" Name="Raw Bytes" Kind="OutputPin" />
@@ -32,13 +34,13 @@
             <Pin Id="ASIIwZxItYPNjD2TdKLgkr" Name="On Data" Kind="OutputPin" />
             <Pin Id="KeMGDtBgnGOMdTC13ILFzQ" Name="In Progress" Kind="OutputPin" />
           </Node>
-          <Pad Id="Q09z9HgVXXcQOIb1cbv4aq" Comment="URL" Bounds="127,169,355,15" ShowValueBox="true" isIOBox="true" Value="https://hub.dummyapis.com/image?text=bonjour&amp;height=120&amp;width=120">
-            <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+          <Pad Id="Q09z9HgVXXcQOIb1cbv4aq" Comment="URL" Bounds="127,169,355,15" ShowValueBox="true" isIOBox="true" Value="https://dummyjson.com/image/400x400/333333/ffffff?text=vvvv">
+            <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="CoreLibBasics.vl">
               <Choice Kind="TypeFlag" Name="String" />
             </p:TypeAnnotation>
           </Pad>
-          <Pad Id="DXTscLq8yp0NxIol09uMss" Comment="Refresh" Bounds="247,219,42,15" ShowValueBox="true" isIOBox="true" Value="False">
-            <p:TypeAnnotation>
+          <Pad Id="DXTscLq8yp0NxIol09uMss" Comment="Refresh" Bounds="247,211,42,15" ShowValueBox="true" isIOBox="true" Value="False">
+            <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
               <Choice Kind="ImmutableTypeFlag" Name="Boolean" />
               <FullNameCategoryReference ID="Primitive" />
             </p:TypeAnnotation>
@@ -48,7 +50,7 @@
           </Pad>
           <Pad Id="Q4HQQHW7xLtNXCU9JwI1sH" Comment="" Bounds="147,410,116,132" ShowValueBox="true" isIOBox="true" />
           <Node Bounds="133,281,34,19" Id="CTfBx9KRGUeOI10LX2xqbS">
-            <p:NodeReference LastCategoryFullName="Collections.Sequence" LastSymbolSource="VL.Collections.vl">
+            <p:NodeReference LastCategoryFullName="Collections.Sequence" LastDependency="VL.Collections.vl">
               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
               <Choice Kind="OperationCallFlag" Name="Any" />
               <CategoryReference Kind="MutableInterfaceType" Name="Sequence" NeedsToBeDirectParent="true" />
@@ -57,7 +59,7 @@
             <Pin Id="LYWMWEtBhxXOlRuXSPH6WF" Name="Result" Kind="OutputPin" />
           </Node>
           <Node Bounds="133,318,123,66" Id="UFD6gGQ7nBLQcsMYDOsj3Q">
-            <p:NodeReference LastCategoryFullName="Primitive" LastSymbolSource="VL.CoreLib.dll">
+            <p:NodeReference LastCategoryFullName="Primitive" LastDependency="Builtin">
               <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
               <Choice Kind="ApplicationStatefulRegion" Name="If" />
               <FullNameCategoryReference ID="Primitive" />
@@ -67,14 +69,14 @@
               <Patch Id="Smfac7iK6MPL8ktrt8sDFl" Name="Create" ManuallySortedPins="true" />
               <Patch Id="QueFweNrOkfMFEtFpUBvyP" Name="Then" ManuallySortedPins="true" />
               <Node Bounds="145,343,99,19" Id="AXASSloR2CcMpA5Ttx47DP">
-                <p:NodeReference LastCategoryFullName="Graphics.Skia.Unwrapped.SKImage" LastSymbolSource="VL.Skia.vl">
+                <p:NodeReference LastCategoryFullName="Graphics.Skia.Unwrapped.SKImage" LastDependency="VL.Skia.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="FromEncodedData" />
                   <PinReference Kind="InputPin" Name="Data">
-                    <p:DataTypeReference p:Type="TypeReference" LastCategoryFullName="Collections.Mutable" LastSymbolSource="VL.Collections.vl">
+                    <p:DataTypeReference p:Type="TypeReference" LastCategoryFullName="Collections.Mutable" LastDependency="VL.Collections.vl">
                       <Choice Kind="TypeFlag" Name="MutableArray" />
                       <p:TypeArguments>
-                        <TypeReference LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+                        <TypeReference LastCategoryFullName="Primitive" LastDependency="CoreLibBasics.vl">
                           <Choice Kind="TypeFlag" Name="Byte" />
                         </TypeReference>
                       </p:TypeArguments>
@@ -86,10 +88,10 @@
               </Node>
             </Patch>
             <ControlPoint Id="Vvg1lpOQU5rNXwo7NL4i7o" Bounds="147,378" Alignment="Bottom" />
-            <ControlPoint Id="QWsotgNJHm0Nzd32tt7uE9" Bounds="189,325" Alignment="Top" />
+            <ControlPoint Id="QWsotgNJHm0Nzd32tt7uE9" Bounds="189,324" Alignment="Top" />
           </Node>
           <Pad Id="QvRqIZtg80UMYosrlr3KOP" Bounds="75,91,425,31" ShowValueBox="true" isIOBox="true" Value="Requesting an image with an HTTP query">
-            <p:TypeAnnotation>
+            <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
               <Choice Kind="TypeFlag" Name="String" />
             </p:TypeAnnotation>
             <p:ValueBoxSettings>
@@ -98,7 +100,7 @@
             </p:ValueBoxSettings>
           </Pad>
           <Pad Id="KD5QVNv5QZuNLZwhZzD2vt" Bounds="69,161,29,27" ShowValueBox="true" isIOBox="true" Value="1.">
-            <p:TypeAnnotation>
+            <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
               <Choice Kind="TypeFlag" Name="String" />
             </p:TypeAnnotation>
             <p:ValueBoxSettings>
@@ -107,7 +109,7 @@
             </p:ValueBoxSettings>
           </Pad>
           <Pad Id="URoZG2bCSdVNg2kQHTPtiL" Bounds="69,282,29,27" ShowValueBox="true" isIOBox="true" Value="2.">
-            <p:TypeAnnotation>
+            <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
               <Choice Kind="TypeFlag" Name="String" />
             </p:TypeAnnotation>
             <p:ValueBoxSettings>
@@ -116,7 +118,7 @@
             </p:ValueBoxSettings>
           </Pad>
           <Pad Id="AKDXQCFzj9ALaQrWTEvZ6o" Bounds="61,594,29,27" ShowValueBox="true" isIOBox="true" Value="1.">
-            <p:TypeAnnotation>
+            <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
               <Choice Kind="TypeFlag" Name="String" />
             </p:TypeAnnotation>
             <p:ValueBoxSettings>
@@ -125,7 +127,7 @@
             </p:ValueBoxSettings>
           </Pad>
           <Pad Id="C62jcqlLF1sPGhmZwZjcOT" Bounds="103,600,602,39" ShowValueBox="true" isIOBox="true" Value="API endpoints can return images as well! This endpoint returns a simple image with the text we specify as a parameter. We can also specify the resolution there.">
-            <p:TypeAnnotation>
+            <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
               <Choice Kind="TypeFlag" Name="String" />
             </p:TypeAnnotation>
             <p:ValueBoxSettings>
@@ -134,7 +136,7 @@
             </p:ValueBoxSettings>
           </Pad>
           <Pad Id="EWbt9pDMt2UQTwTpp6V5tl" Bounds="103,686,621,39" ShowValueBox="true" isIOBox="true" Value="To retrieve that image, we must enable the Optional &quot;Raw Bytes&quot; output pin. Instead of giving us the string result of the query, it gives us... well, the raw bytes.">
-            <p:TypeAnnotation>
+            <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
               <Choice Kind="TypeFlag" Name="String" />
             </p:TypeAnnotation>
             <p:ValueBoxSettings>
@@ -143,7 +145,7 @@
             </p:ValueBoxSettings>
           </Pad>
           <Pad Id="AnN8IQOJeJJNVEzgHdYK9y" Bounds="61,684,29,27" ShowValueBox="true" isIOBox="true" Value="2.">
-            <p:TypeAnnotation>
+            <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
               <Choice Kind="TypeFlag" Name="String" />
             </p:TypeAnnotation>
             <p:ValueBoxSettings>
@@ -152,7 +154,7 @@
             </p:ValueBoxSettings>
           </Pad>
           <Pad Id="S8R92v369jbMdUE5qOaa3i" Bounds="69,340,29,27" ShowValueBox="true" isIOBox="true" Value="3.">
-            <p:TypeAnnotation>
+            <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
               <Choice Kind="TypeFlag" Name="String" />
             </p:TypeAnnotation>
             <p:ValueBoxSettings>
@@ -161,7 +163,7 @@
             </p:ValueBoxSettings>
           </Pad>
           <Pad Id="KlR2N0M4SmLO0BqSnrto5J" Bounds="102,763,613,19" ShowValueBox="true" isIOBox="true" Value="We do some Skia magic to recompose the image from the raw data we received">
-            <p:TypeAnnotation>
+            <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
               <Choice Kind="TypeFlag" Name="String" />
             </p:TypeAnnotation>
             <p:ValueBoxSettings>
@@ -170,7 +172,7 @@
             </p:ValueBoxSettings>
           </Pad>
           <Pad Id="Vgl2aPQpumFPn9jc4WU4QI" Bounds="61,758,29,27" ShowValueBox="true" isIOBox="true" Value="3.">
-            <p:TypeAnnotation>
+            <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
               <Choice Kind="TypeFlag" Name="String" />
             </p:TypeAnnotation>
             <p:ValueBoxSettings>
@@ -196,7 +198,7 @@
       </Patch>
     </Node>
   </Patch>
-  <NugetDependency Id="OYVlUEiqm5OO2GTXjDy5YJ" Location="VL.CoreLib" Version="2021.4.6" />
+  <NugetDependency Id="OYVlUEiqm5OO2GTXjDy5YJ" Location="VL.CoreLib" Version="2025.7.1-0042-gb4eb70cb8e" />
   <NugetDependency Id="IrudDYmisQlQRb6InhZ54e" Location="VL.SimpleHTTP" Version="0.0.0.0" />
-  <NugetDependency Id="QhziyJ29n9LMMEcwUiRzM2" Location="VL.Skia" Version="2021.4.6" />
+  <NugetDependency Id="QhziyJ29n9LMMEcwUiRzM2" Location="VL.Skia" Version="2025.7.1-0042-gb4eb70cb8e" />
 </Document>

--- a/help/HowTo Use the Advanced SimpleHTTP nodes.vl
+++ b/help/HowTo Use the Advanced SimpleHTTP nodes.vl
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Document xmlns:p="property" Id="OaSqBynOd03ODGG1tRgHbg" LanguageVersion="2021.4.8.937" Version="0.128">
+<Document xmlns:p="property" xmlns:r="reflection" Id="OaSqBynOd03ODGG1tRgHbg" LanguageVersion="2025.7.1-0042-gb4eb70cb8e" Version="0.128">
   <Patch Id="VobCKxjpTwYODvgSxHZCjz">
     <Canvas Id="EBfIO5ZJ6PRNQt5Q0znAOP" DefaultCategory="Main" BordersChecked="false" CanvasType="FullCategory" />
     <!--
@@ -14,27 +14,31 @@
       </p:NodeReference>
       <Patch Id="DXgv1hooHFQNnPPxLM4gF4">
         <Canvas Id="JGK1rFTzOgWLEkyO6Vvax2" CanvasType="Group">
-          <Node Bounds="123,224,85,19" Id="IocZ2Epai3mMXfnNPCSGbZ">
-            <p:NodeReference LastCategoryFullName="IO.HTTP" LastSymbolSource="VL.SimpleHTTP.vl">
+          <Node Bounds="123,224,105,19" Id="IocZ2Epai3mMXfnNPCSGbZ">
+            <p:NodeReference LastCategoryFullName="IO.HTTP" LastDependency="VL.SimpleHTTP.vl">
               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
               <Choice Kind="ProcessAppFlag" Name="Request (Async Reactive)" />
             </p:NodeReference>
+            <Pin Id="S23aSBHrsNBM02v3Rfk7hF" Name="Node Context" Kind="InputPin" IsHidden="true" />
             <Pin Id="Q8m3tgM0vn2NZdY6hYfhVz" Name="URL" Kind="InputPin" />
             <Pin Id="AJFJLu1AtXtNUqTXHpdfXu" Name="Headers" Kind="InputPin" />
             <Pin Id="N5BwvQIi9pvMRtqdvxHCjj" Name="Body" Kind="InputPin" />
             <Pin Id="NLgkWG5H13FM7FQLMbNcxj" Name="Method" Kind="InputPin" />
+            <Pin Id="GFiLThE88T9P6GdJaHfhwQ" Name="Timeout" Kind="InputPin" />
             <Pin Id="Qcg8e8NbOEePu9NkbTpX2X" Name="Refresh" Kind="InputPin" />
             <Pin Id="Fg5eJ0fcDq5L3RcNbeXbNC" Name="Result" Kind="OutputPin" />
             <Pin Id="Uevb69TKeXCLluHD8lItfE" Name="In Progress" Kind="OutputPin" />
           </Node>
           <Node Bounds="123,266,121,148" Id="TSBv3KcX1BnN0JqZZspgHD">
-            <p:NodeReference LastCategoryFullName="Reactive" LastSymbolSource="VL.Reactive.vl">
+            <p:NodeReference LastCategoryFullName="Reactive" LastDependency="VL.Reactive.vl">
               <Choice Kind="ProcessAppFlag" Name="ForEach" />
               <CategoryReference Kind="Category" Name="Reactive" NeedsToBeDirectParent="true" />
               <Choice Kind="StatefulRegion" Name="Region (Stateful)" Fixed="true" />
             </p:NodeReference>
+            <Pin Id="D4miShLM3DFPEftCSqWYaQ" Name="Node Context" Kind="InputPin" IsHidden="true" />
             <Pin Id="RD2NWFLdijWN6TALiT8En3" Name="Messages" Kind="InputPin" />
             <Pin Id="MRE1hcZ6VMMOSm3lQWLBXY" Name="Reset" Kind="InputPin" />
+            <Pin Id="IimIuRTinRSQFTAigXxnzb" Name="Output" Kind="OutputPin" IsHidden="true" />
             <Pin Id="Hx4CrsBrXDyPtr8vrKbCf5" Name="Result" Kind="OutputPin" />
             <Patch Id="Ed9LQ8zYJwSOzfs6d6whcC" ManuallySortedPins="true">
               <Patch Id="QLbrwto2Qy8NRL02urpMqh" Name="Create" ManuallySortedPins="true" />
@@ -45,12 +49,13 @@
               <ControlPoint Id="FWiPL0MtpSyPBrFGNg2h6P" Bounds="137,274" />
               <ControlPoint Id="IPxcYDagjSiLmJXtN66mF0" Bounds="137,407" />
               <Node Bounds="135,295,85,26" Id="GdumU0OOS6EMLaYOuxb1oI">
-                <p:NodeReference LastCategoryFullName="IO.HTTP.ResponseData" LastSymbolSource="VL.SimpleHTTP.vl">
+                <p:NodeReference LastCategoryFullName="IO.HTTP.ResponseData" LastDependency="VL.SimpleHTTP.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <CategoryReference Kind="RecordType" Name="ResponseData" />
                   <Choice Kind="OperationCallFlag" Name="Split" />
                 </p:NodeReference>
                 <Pin Id="PrtY14nKcGBLjeidzlskU7" Name="Input" Kind="StateInputPin" />
+                <Pin Id="T6tcHKday5vOZI4PEzmHA5" Name="Output" Kind="OutputPin" IsHidden="true" />
                 <Pin Id="FMS8rtoaj9kPEiNGFbEQx6" Name="Content" Kind="OutputPin" />
                 <Pin Id="VpqrUuQycbbMnfMVn96jk3" Name="Raw Bytes" Kind="OutputPin" />
                 <Pin Id="AoAC3L317qNQWexxPb8KKx" Name="Status Code" Kind="OutputPin" />
@@ -58,7 +63,7 @@
                 <Pin Id="CmTI72p3zPCQVXIh46nrbQ" Name="Is Successful" Kind="OutputPin" />
               </Node>
               <Node Bounds="174,349,58,26" Id="LB61s5h2WVSOiOTzNg1WDR">
-                <p:NodeReference LastCategoryFullName="System.Console" LastSymbolSource="CoreLibBasics.vl">
+                <p:NodeReference LastCategoryFullName="System.Console" LastDependency="CoreLibBasics.vl">
                   <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
                   <Choice Kind="OperationCallFlag" Name="WriteLine" />
                 </p:NodeReference>
@@ -67,23 +72,26 @@
               </Node>
             </Patch>
           </Node>
-          <Pad Id="ShSzerZtuPfQQwF3LAtSK9" Comment="URL" Bounds="125,185,246,15" ShowValueBox="true" isIOBox="true" Value="https://hub.dummyapis.com/delay?seconds=1">
-            <p:TypeAnnotation LastCategoryFullName="Primitive" LastSymbolSource="CoreLibBasics.vl">
+          <Pad Id="ShSzerZtuPfQQwF3LAtSK9" Comment="URL" Bounds="125,185,246,15" ShowValueBox="true" isIOBox="true" Value="https://dummyjson.com/RESOURCE/?delay=1000">
+            <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="CoreLibBasics.vl">
               <Choice Kind="TypeFlag" Name="String" />
             </p:TypeAnnotation>
           </Pad>
           <Node Bounds="123,435,65,19" Id="A93CfdG6JKPPuTNhMyFL1e">
-            <p:NodeReference LastCategoryFullName="Reactive" LastSymbolSource="VL.Reactive.vl">
+            <p:NodeReference LastCategoryFullName="Reactive" LastDependency="VL.Reactive.vl">
               <Choice Kind="NodeFlag" Name="Node" Fixed="true" />
               <Choice Kind="ProcessAppFlag" Name="HoldLatest" />
             </p:NodeReference>
+            <Pin Id="BS6AXrucieVO6xrE4YjyFt" Name="Node Context" Kind="InputPin" IsHidden="true" />
+            <Pin Id="G2ftVnSxxtlLia4eTrmuc9" Name="Initial Result" Kind="InputPin" IsHidden="true" />
             <Pin Id="GMqy3d641SeNNV527k4NYr" Name="Async Notifications" Kind="InputPin" />
             <Pin Id="ApvGMAzC8VmNwFPE8C6FWz" Name="Reset" Kind="InputPin" />
+            <Pin Id="AeNKK1os3F2PPbMLBZfI5T" Name="Output" Kind="OutputPin" IsHidden="true" />
             <Pin Id="BY3PKq2DnfjMd0ku6vQ620" Name="Value" Kind="OutputPin" />
             <Pin Id="NYkaRMmAoGaPXaVBsKE0R8" Name="On Data" Kind="OutputPin" />
           </Node>
-          <Pad Id="AV2YDrFuYCsPI1OvvWnFGr" Comment="Refresh" Bounds="205,210,35,15" ShowValueBox="true" isIOBox="true" Value="False">
-            <p:TypeAnnotation>
+          <Pad Id="AV2YDrFuYCsPI1OvvWnFGr" Comment="Refresh" Bounds="225,201,35,15" ShowValueBox="true" isIOBox="true" Value="False">
+            <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
               <Choice Kind="ImmutableTypeFlag" Name="Boolean" />
               <FullNameCategoryReference ID="Primitive" />
             </p:TypeAnnotation>
@@ -93,7 +101,7 @@
           </Pad>
           <Pad Id="PDcAYgVNYUkPILXpcklk33" Comment="" Bounds="125,474,164,180" ShowValueBox="true" isIOBox="true" />
           <Pad Id="Jc0FcHYxGnlOhPBSkI8d3L" Bounds="115,101,557,38" ShowValueBox="true" isIOBox="true" Value="The Advanced Request node works like the normal Async one, except that it outputs its result as an Observable.">
-            <p:TypeAnnotation>
+            <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
               <Choice Kind="TypeFlag" Name="String" />
             </p:TypeAnnotation>
             <p:ValueBoxSettings>
@@ -102,7 +110,7 @@
             </p:ValueBoxSettings>
           </Pad>
           <Pad Id="HyKPxjTPve3Pv7I7qgwBab" Bounds="32,180,29,27" ShowValueBox="true" isIOBox="true" Value="1.">
-            <p:TypeAnnotation>
+            <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
               <Choice Kind="TypeFlag" Name="String" />
             </p:TypeAnnotation>
             <p:ValueBoxSettings>
@@ -111,7 +119,7 @@
             </p:ValueBoxSettings>
           </Pad>
           <Pad Id="UsQQD67ZgeWN4d3Q0xtwX1" Bounds="32,267,29,27" ShowValueBox="true" isIOBox="true" Value="2.">
-            <p:TypeAnnotation>
+            <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
               <Choice Kind="TypeFlag" Name="String" />
             </p:TypeAnnotation>
             <p:ValueBoxSettings>
@@ -120,7 +128,7 @@
             </p:ValueBoxSettings>
           </Pad>
           <Pad Id="KrDCORafO50OD7vNaTMFWC" Bounds="349,395,29,27" ShowValueBox="true" isIOBox="true" Value="2.">
-            <p:TypeAnnotation>
+            <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
               <Choice Kind="TypeFlag" Name="String" />
             </p:TypeAnnotation>
             <p:ValueBoxSettings>
@@ -129,7 +137,7 @@
             </p:ValueBoxSettings>
           </Pad>
           <Pad Id="Dug2SQWf7SdMxTlddUrbmg" Bounds="387,395,325,102" ShowValueBox="true" isIOBox="true" Value="The ForEach (Reactive) region will execute soon as it gets an Observable firing on its input pin.&#xD;&#xA;You can verify this by opening a Console (CTRL + F1) execute the query : soon as the query succeeds, a message will be printed to the console.">
-            <p:TypeAnnotation>
+            <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
               <Choice Kind="TypeFlag" Name="String" />
             </p:TypeAnnotation>
             <p:ValueBoxSettings>
@@ -138,7 +146,7 @@
             </p:ValueBoxSettings>
           </Pad>
           <Pad Id="URBE7kkPTtIO43i7faGr6Q" Bounds="32,317,29,27" ShowValueBox="true" isIOBox="true" Value="3.">
-            <p:TypeAnnotation>
+            <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
               <Choice Kind="TypeFlag" Name="String" />
             </p:TypeAnnotation>
             <p:ValueBoxSettings>
@@ -147,7 +155,7 @@
             </p:ValueBoxSettings>
           </Pad>
           <Pad Id="Tqz4xRLpnRFMHfBiTFE35Z" Bounds="349,276,29,27" ShowValueBox="true" isIOBox="true" Value="1.">
-            <p:TypeAnnotation>
+            <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
               <Choice Kind="TypeFlag" Name="String" />
             </p:TypeAnnotation>
             <p:ValueBoxSettings>
@@ -156,7 +164,7 @@
             </p:ValueBoxSettings>
           </Pad>
           <Pad Id="H9WGNCZb8XRMisOx4PAV8M" Bounds="387,276,324,84" ShowValueBox="true" isIOBox="true" Value="This API endpoint does not do anything special, it just replies with an arbitrary delay in seconds. Could be useful to debug things in larger projects, just saying.">
-            <p:TypeAnnotation>
+            <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
               <Choice Kind="TypeFlag" Name="String" />
             </p:TypeAnnotation>
             <p:ValueBoxSettings>
@@ -165,7 +173,7 @@
             </p:ValueBoxSettings>
           </Pad>
           <Pad Id="Cj5QaVsCeh6Mz0VzXu1kWD" Bounds="349,526,29,27" ShowValueBox="true" isIOBox="true" Value="3.">
-            <p:TypeAnnotation>
+            <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
               <Choice Kind="TypeFlag" Name="String" />
             </p:TypeAnnotation>
             <p:ValueBoxSettings>
@@ -174,7 +182,7 @@
             </p:ValueBoxSettings>
           </Pad>
           <Pad Id="S1Fei5WC6TOMTWhEvSAezc" Bounds="387,526,327,63" ShowValueBox="true" isIOBox="true" Value="The content of the response is stuffed in a ResponseData object that we can split using the Split node.">
-            <p:TypeAnnotation>
+            <p:TypeAnnotation LastCategoryFullName="Primitive" LastDependency="VL.CoreLib.vl">
               <Choice Kind="TypeFlag" Name="String" />
             </p:TypeAnnotation>
             <p:ValueBoxSettings>
@@ -202,6 +210,6 @@
       </Patch>
     </Node>
   </Patch>
-  <NugetDependency Id="P0tvu6YEA2XNMO9JIGi5Rc" Location="VL.CoreLib" Version="2021.4.8-0937-g24dbdf088c" />
+  <NugetDependency Id="P0tvu6YEA2XNMO9JIGi5Rc" Location="VL.CoreLib" Version="2025.7.1-0042-gb4eb70cb8e" />
   <NugetDependency Id="Qru5pEyQJFLPRBJ9LueX9o" Location="VL.SimpleHTTP" Version="0.0.0.0" />
 </Document>


### PR DESCRIPTION
Mainly:
* Updates to RestSharp 112.1.0
* Adds timeout parameter to requests
* Changes api endpoints in help patches to https://dummyjson.com since https://hub.dummyapis.com is no longer working.
